### PR TITLE
Relax rhumsaa/uuid version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "rhumsaa/uuid" : "2.5.*",
+        "rhumsaa/uuid" : "~2.5",
         "beberlei/assert": "*",
         "zendframework/zend-servicemanager" : "~2.3",
         "zendframework/zend-eventmanager" : "~2.3",


### PR DESCRIPTION
Is there any reason why you require `2.5.*` of rhumsaa/uuid? This prevents me from using the latest stable version `2.7.2`. I think, requiring `~2.5` should be ok.
