### PR TITLE
Composer tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ You can install ProophEventStore via composer by adding `"prooph/event-store": "
  * "require": {
  * "php": ">=5.4",
  *   "prooph/event-store" : "dev-master",
- *   "prooph/event-sourcing": "dev-master" //Default event-sourcing library
+ *   "prooph/event-sourcing": "dev-master", //Default event-sourcing library
+     "zendframework/zend-db" : "~2.3",
+     "zendframework/zend-serializer" : "~2.3"
  * },
  */
 namespace {

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,20 @@
         "rhumsaa/uuid" : "~2.5",
         "beberlei/assert": "*",
         "zendframework/zend-servicemanager" : "~2.3",
-        "zendframework/zend-eventmanager" : "~2.3",
-        "zendframework/zend-db" : "~2.3",
-        "zendframework/zend-serializer" : "~2.3"
+        "zendframework/zend-eventmanager" : "~2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
-        "prooph/event-sourcing" : "dev-master"
+        "prooph/event-sourcing" : "dev-master",
+        "zendframework/zend-db" : "~2.3",
+        "zendframework/zend-serializer" : "~2.3"
     },
     "suggest" : {
         "prooph/event-sourcing" : "Basic functionality for event sourced aggregates",
         "prooph/service-bus" : "Enterprise Service Bus adapter to connect EventStore with messaging systems",
-        "prooph/crud-bridge" : "Handle CRUD-ish entities with CQRS + ES"
+        "prooph/crud-bridge" : "Handle CRUD-ish entities with CQRS + ES",
+        "zendframework/zend-db" : "Required when using the Zf2EventStoreAdapter",
+        "zendframework/zend-serializer" : "Required when using the Zf2EventStoreAdapter"
     },
     "autoload": {
         "psr-0": { 

--- a/examples/quickstart.php
+++ b/examples/quickstart.php
@@ -29,7 +29,9 @@
  * "require": {
  * "php": ">=5.4",
  *   "prooph/event-store" : "dev-master",
- *   "prooph/event-sourcing": "dev-master" //Default event-sourcing library
+ *   "prooph/event-sourcing": "dev-master", //Default event-sourcing library
+ *   "zendframework/zend-db" : "~2.3",
+ *   "zendframework/zend-serializer" : "~2.3"
  * },
  */
 namespace {


### PR DESCRIPTION
1. Moved autoloading of test classes to autoload-dev. This should be a no-brainer.
2. Made zendframework/zend-db an optional dependency. Not sure if you really want this. I will write a Doctrine adapter for my current project as it already uses Doctrine (i can contribute it back if you're interested), so i don't need Zend\Db. If you don't like this change, feel free to only cherry-pick the other commit.
