### PR TITLE
Reset event store recorded events collection before triggering post commit event

### DIFF
--- a/src/Prooph/EventStore/EventStore.php
+++ b/src/Prooph/EventStore/EventStore.php
@@ -311,9 +311,9 @@ class EventStore
 
         $event = new PostCommitEvent(__FUNCTION__ . '.post', $this, $argv);
 
-        $this->getActionEventDispatcher()->dispatch($event);
-
         $this->recordedEvents = [];
+
+        $this->getActionEventDispatcher()->dispatch($event);
     }
 
     /**


### PR DESCRIPTION
When the event store triggers the post commit event all the transaction related aspect must be closed. The collection of recorded events stored during the transaction and made persistent into the event store
must be empty.
If the listener of the "post commit" event wants to start a new transaction it have not to take care of the reset of the recorded events collection. It's not its responsibility. If the collection isn't empty the events of the new transaction will be added to the old ones and sent at the new post commit event generating a loop.
If the listener is interested into what events has been committed it can look into the event itself using the `getRecordedEvents` method.