### PR TITLE
Avoid config conflicts with adapter factories

### DIFF
--- a/src/Container/EventStoreFactory.php
+++ b/src/Container/EventStoreFactory.php
@@ -42,10 +42,10 @@ final class EventStoreFactory
 
         $config = $config['prooph']['event_store'];
 
-        if (!isset($config['adapter'])) {
+        if (!isset($config['adapter']['type'])) {
             $adapter = new InMemoryAdapter();
         } else {
-            $adapter = $container->get($config['adapter']);
+            $adapter = $container->get($config['adapter']['type']);
         }
 
         if (!isset($config['event_emitter'])) {

--- a/tests/Container/EventStoreFactoryTest.php
+++ b/tests/Container/EventStoreFactoryTest.php
@@ -50,7 +50,7 @@ class EventStoreFactoryTest extends TestCase
      */
     public function it_injects_custom_adapter()
     {
-        $config['prooph']['event_store']['adapter'] = 'adapter';
+        $config['prooph']['event_store']['adapter']['type'] = 'adapter';
 
         $adapterMock = $this->getMockForAbstractClass(Adapter::class);
 


### PR DESCRIPTION
While documenting the event store factory I recognized that we have a conflict in the config structure.
The event store factory expects a `string` for `prooph.event_store.adapter` while the adapter factories expect an `array` containing a `options` key.

To avoid such conflicts this PR changes the event store factory to look for a `type` key within the `adapter` config for the service id of the adapter.