### PR TITLE
Adjust AggregateTranslator contract

### DIFF
--- a/src/Aggregate/AggregateTranslator.php
+++ b/src/Aggregate/AggregateTranslator.php
@@ -29,10 +29,10 @@ interface AggregateTranslator
 
     /**
      * @param AggregateType $aggregateType
-     * @param Message[] $historyEvents
+     * @param \Iterator $historyEvents
      * @return object reconstructed EventSourcedAggregateRoot
      */
-    public function reconstituteAggregateFromHistory(AggregateType $aggregateType, $historyEvents);
+    public function reconstituteAggregateFromHistory(AggregateType $aggregateType, \Iterator $historyEvents);
 
     /**
      * @param object $eventSourcedAggregateRoot

--- a/src/Aggregate/ConfigurableAggregateTranslator.php
+++ b/src/Aggregate/ConfigurableAggregateTranslator.php
@@ -14,6 +14,7 @@ namespace Prooph\EventStore\Aggregate;
 use Assert\Assertion;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\Aggregate\Exception\AggregateTranslationFailedException;
+use Prooph\EventStore\Util\MapIterator;
 
 /**
  * Class ConfigurableAggregateTranslator
@@ -123,14 +124,14 @@ class ConfigurableAggregateTranslator implements AggregateTranslator
 
     /**
      * @param AggregateType $aggregateType
-     * @param Message[] $historyEvents
+     * @param \Iterator $historyEvents
      * @throws Exception\AggregateTranslationFailedException
      * @return object reconstructed EventSourcedAggregateRoot
      */
-    public function reconstituteAggregateFromHistory(AggregateType $aggregateType, $historyEvents)
+    public function reconstituteAggregateFromHistory(AggregateType $aggregateType, \Iterator $historyEvents)
     {
         if ($this->messageToEventCallback) {
-            $historyEvents = array_map($this->messageToEventCallback, $historyEvents);
+            $historyEvents = new MapIterator($historyEvents, $this->messageToEventCallback);
         }
 
         $aggregateClass = $aggregateType->toString();

--- a/src/Util/MapIterator.php
+++ b/src/Util/MapIterator.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * This file is part of the prooph/event-store.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 9/28/15 - 7:46 PM
+ */
+namespace Prooph\EventStore\Util;
+
+/**
+ * Class MapIterator
+ *
+ * @package Prooph\EventStore\Util
+ */
+final class MapIterator extends \IteratorIterator
+{
+    /**
+     * @var callable
+     */
+    private $callback;
+
+    /**
+     * @param \Traversable $iterator
+     * @param callable $callback
+     */
+    public function __construct(\Traversable $iterator, callable $callback)
+    {
+        parent::__construct($iterator);
+        $this->callback = $callback;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function current()
+    {
+        $iterator = $this->getInnerIterator();
+        $callback = $this->callback;
+        return $callback(parent::current(), parent::key(), $iterator);
+    }
+}

--- a/tests/Aggregate/ConfigurableAggregateTranslatorTest.php
+++ b/tests/Aggregate/ConfigurableAggregateTranslatorTest.php
@@ -236,13 +236,13 @@ final class ConfigurableAggregateTranslatorTest extends TestCase
     {
         $historyEvent = $this->prophesize(Message::class);
 
-        $historyEvents = [$historyEvent->reveal()];
+        $historyEvents = new \ArrayIterator([$historyEvent->reveal()]);
 
         $translator = new ConfigurableAggregateTranslator();
 
         $ar = $translator->reconstituteAggregateFromHistory(AggregateType::fromAggregateRootClass(DefaultAggregateRoot::class), $historyEvents);
 
-        $this->assertSame($historyEvents, $ar->getHistoryEvents());
+        $this->assertSame(iterator_to_array($historyEvents), $ar->getHistoryEvents());
     }
 
     /**
@@ -252,7 +252,7 @@ final class ConfigurableAggregateTranslatorTest extends TestCase
     {
         $historyEvent = $this->prophesize(Message::class);
 
-        $historyEvents = [$historyEvent->reveal()];
+        $historyEvents = new \ArrayIterator([$historyEvent->reveal()]);
 
         $translator = new ConfigurableAggregateTranslator(null, null, null, 'buildFromHistoryEvents');
 
@@ -278,7 +278,7 @@ final class ConfigurableAggregateTranslatorTest extends TestCase
     {
         $translator = new ConfigurableAggregateTranslator();
 
-        $translator->reconstituteAggregateFromHistory(AggregateType::fromString('UnknownClass'), []);
+        $translator->reconstituteAggregateFromHistory(AggregateType::fromString('UnknownClass'), new \ArrayIterator([]));
     }
 
     /**
@@ -289,7 +289,7 @@ final class ConfigurableAggregateTranslatorTest extends TestCase
     {
         $translator = new ConfigurableAggregateTranslator(null, null, null, 'unknownMethod');
 
-        $translator->reconstituteAggregateFromHistory(AggregateType::fromString(DefaultAggregateRoot::class), []);
+        $translator->reconstituteAggregateFromHistory(AggregateType::fromString(DefaultAggregateRoot::class), new \ArrayIterator([]));
     }
 
     /**
@@ -300,7 +300,7 @@ final class ConfigurableAggregateTranslatorTest extends TestCase
     {
         $translator = new ConfigurableAggregateTranslator();
 
-        $translator->reconstituteAggregateFromHistory(AggregateType::fromString(FaultyAggregateRoot::class), []);
+        $translator->reconstituteAggregateFromHistory(AggregateType::fromString(FaultyAggregateRoot::class), new \ArrayIterator([]));
     }
 
     /**
@@ -310,7 +310,7 @@ final class ConfigurableAggregateTranslatorTest extends TestCase
     {
         $historyEvent = $this->prophesize(Message::class);
 
-        $historyEvents = [$historyEvent->reveal()];
+        $historyEvents = new \ArrayIterator([$historyEvent->reveal()]);
 
         $translator = new ConfigurableAggregateTranslator(null, null, null, null, null, function (Message $message) {
             return ['custom' => 'domainEvent'];

--- a/tests/Mock/DefaultAggregateRoot.php
+++ b/tests/Mock/DefaultAggregateRoot.php
@@ -27,11 +27,11 @@ final class DefaultAggregateRoot implements DefaultAggregateRootContract
      * @param Message[] $historyEvents
      * @return DefaultAggregateRootContract
      */
-    public static function reconstituteFromHistory($historyEvents)
+    public static function reconstituteFromHistory(\Iterator $historyEvents)
     {
         $self = new self();
 
-        $self->historyEvents = $historyEvents;
+        $self->historyEvents = iterator_to_array($historyEvents);
 
         return $self;
     }

--- a/tests/Mock/DefaultAggregateRootContract.php
+++ b/tests/Mock/DefaultAggregateRootContract.php
@@ -22,10 +22,10 @@ use Prooph\Common\Messaging\Message;
 interface DefaultAggregateRootContract
 {
     /**
-     * @param Message[] $historyEvents
+     * @param \Iterator $historyEvents
      * @return DefaultAggregateRootContract
      */
-    public static function reconstituteFromHistory($historyEvents);
+    public static function reconstituteFromHistory(\Iterator $historyEvents);
 
     /**
      * @return string

--- a/tests/Mock/FaultyAggregateRoot.php
+++ b/tests/Mock/FaultyAggregateRoot.php
@@ -23,10 +23,10 @@ final class FaultyAggregateRoot implements DefaultAggregateRootContract
 {
 
     /**
-     * @param Message[] $historyEvents
+     * @param \Iterator $historyEvents
      * @return DefaultAggregateRootContract
      */
-    public static function reconstituteFromHistory($historyEvents)
+    public static function reconstituteFromHistory(\Iterator $historyEvents)
     {
         //faulty method
         return;


### PR DESCRIPTION
The ConfigurableAggregateTranslator caused trouble when reconstituting an aggregate in combination with a custom `messageToEventCallback`. In this case the translator used `array_map` but got an `\Iterator $historyEvents`.

This PR changes the `AggregateTranslator::reconstituteAggregateFromHistory` contract to require a `\Iterator $historyEvents` parameter.

Also a new `MapIterator` is introduced to replace the `array_map` functionality.

Additionally I've renamed `AggregateRepository::__invoke` to `AggregateRepository::addPendingEventsToStream` to unify the listener methods and improve readability of the code.