### PR TITLE
Handle pending events of new aggregates correctly

### DIFF
--- a/tests/Aggregate/AggregateRepositoryTest.php
+++ b/tests/Aggregate/AggregateRepositoryTest.php
@@ -69,7 +69,7 @@ class AggregateRepositoryTest extends TestCase
             $user->getId()->toString()
         );
 
-        $this->assertInstanceOf('Prooph\EventStoreTest\Mock\User', $user);
+        $this->assertInstanceOf('Prooph\EventStoreTest\Mock\User', $fetchedUser);
 
         $this->assertNotSame($user, $fetchedUser);
 
@@ -129,6 +129,10 @@ class AggregateRepositoryTest extends TestCase
         $user2 = User::create('Max Mustermann', 'some@mail.com');
 
         $this->repository->addAggregateRoot($user2);
+
+        $this->eventStore->commit();
+
+        $this->eventStore->beginTransaction();
 
         $user->changeName('Daniel Doe');
         $user2->changeName('Jens Mustermann');

--- a/tests/Mock/CustomAggregateRoot.php
+++ b/tests/Mock/CustomAggregateRoot.php
@@ -24,10 +24,10 @@ final class CustomAggregateRoot implements CustomAggregateRootContract
     private $historyEvents = [];
 
     /**
-     * @param Message[] $historyEvents
+     * @param \Iterator $historyEvents
      * @return CustomAggregateRootContract
      */
-    public static function buildFromHistoryEvents($historyEvents)
+    public static function buildFromHistoryEvents(\Iterator $historyEvents)
     {
         $self = new self();
 

--- a/tests/Mock/CustomAggregateRootContract.php
+++ b/tests/Mock/CustomAggregateRootContract.php
@@ -22,10 +22,10 @@ use Prooph\Common\Messaging\Message;
 interface CustomAggregateRootContract
 {
     /**
-     * @param Message[] $historyEvents
+     * @param \Iterator $historyEvents
      * @return CustomAggregateRootContract
      */
-    public static function buildFromHistoryEvents($historyEvents);
+    public static function buildFromHistoryEvents(\Iterator $historyEvents);
 
     /**
      * @return string

--- a/tests/Mock/DefaultAggregateRoot.php
+++ b/tests/Mock/DefaultAggregateRoot.php
@@ -24,7 +24,7 @@ final class DefaultAggregateRoot implements DefaultAggregateRootContract
     private $historyEvents = [];
 
     /**
-     * @param Message[] $historyEvents
+     * @param \Iterator $historyEvents
      * @return DefaultAggregateRootContract
      */
     public static function reconstituteFromHistory(\Iterator $historyEvents)

--- a/tests/Mock/User.php
+++ b/tests/Mock/User.php
@@ -118,8 +118,6 @@ class User
     private function recordThat(TestDomainEvent $domainEvent)
     {
         $this->recordedEvents[] = $domainEvent;
-
-        $this->apply($domainEvent);
     }
 
     public function apply(TestDomainEvent $event)


### PR DESCRIPTION
While working on a new version for prooph/event-sourcing (that respects the changes made for prooph/event-store v6) I recognized that the "apply events late" feature does not work for new aggregate roots added to the repository. I was wondering why event store tests were green.
[This](https://github.com/prooph/event-store/blob/master/tests/Mock/User.php#L122) is the answer.
The mock used to test the aggregate repository was not aligned and continued to apply events directly.

This PR changes the internals of the `AggregateRepository` again to also apply events late for newly added aggregate roots. Unfortunately, this was not a straightforward task. Two problems caused a hard time. 

1. At the time when the aggregate root is added to the repository we cannot extract the aggregate id because events are not applied yet.  I've solved the problem by creating a temporary copy of the aggregate root which I can pass to the aggregate translator to get the aggregate id :P

2. Pending events for new aggregate roots need to be stored in the cache, too. So that the events are also applied in the `EventStore.commit.post` listener of the `AggregateRepository`. So fare no problem but `AggregateRepository::addPendingEventsToStream` did override the pending events for new aggregates. 

Long Story, short. I've changed the way of caching pending events to have them next to the aggregate root and have a better control over adding or clearing the events cache.