### PR TITLE
Introduce identity map as first-class object

### DIFF
--- a/src/Aggregate/AggregateType.php
+++ b/src/Aggregate/AggregateType.php
@@ -34,7 +34,7 @@ class AggregateType
     public static function fromAggregateRoot($eventSourcedAggregateRoot)
     {
         if (! is_object($eventSourcedAggregateRoot)) {
-            throw new Exception\InvalidArgumentException(
+            throw new Exception\AggregateTypeException(
                 sprintf('Aggregate root must be an object but type of %s given', gettype($eventSourcedAggregateRoot))
             );
         }
@@ -104,6 +104,21 @@ class AggregateType
     public function __toString()
     {
         return $this->toString();
+    }
+
+    /**
+     * @param $aggregateRoot
+     * @throws Exception\AggregateTypeException
+     */
+    public function assert($aggregateRoot)
+    {
+        $otherAggregateType = self::fromAggregateRoot($aggregateRoot);
+
+        if (! $this->equals($otherAggregateType)) {
+            throw new Exception\AggregateTypeException(
+                sprintf('Aggregate types must be equal. %s != %s', $this->toString(), $otherAggregateType->toString())
+            );
+        }
     }
 
     /**

--- a/src/Aggregate/IdentityMap.php
+++ b/src/Aggregate/IdentityMap.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ * This file is part of the prooph/event-store.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 10/7/15 - 10:09 PM
+ */
+
+namespace Prooph\EventStore\Aggregate;
+
+/**
+ * Interface IdentityMap
+ *
+ * The identity map is an alternative storage for aggregate roots.
+ * It is used by a repository to "cache" aggregate roots for later use without the need
+ * to load and replay history events. The identity map should behave like an in-memory storage.
+ *
+ * The identity map MUST be able to flag aggregate roots as dirty as long as the cleanUp method is not called.
+ * See method doc blocks for more details!
+ *
+ * @package Prooph\EventStore\Aggregate
+ */
+interface IdentityMap
+{
+    /**
+     * Add aggregate root to the identity map
+     * The aggregate root MUST be flagged as dirty
+     * so that {@method getAllDirtyAggregateRoots} returns the AR
+     * as long as {@method cleanUp} is not called
+     *
+     * @param AggregateType $aggregateType
+     * @param string $aggregateId
+     * @param object $aggregateRoot
+     * @return void
+     */
+    public function add(AggregateType $aggregateType, $aggregateId, $aggregateRoot);
+
+    /**
+     * Returns true if it has an aggregate root in the identity map
+     *
+     * @param AggregateType $aggregateType
+     * @param string $aggregateId
+     * @return bool
+     */
+    public function has(AggregateType $aggregateType, $aggregateId);
+
+    /**
+     * Get the aggregate root if it exists otherwise null
+     * The returned aggregate root MUST be flagged as dirty internally
+     * so that {@method getAllDirtyAggregateRoots} returns the AR
+     * as long as {@method cleanUp} is not called
+     *
+     * @param AggregateType $aggregateType
+     * @param string $aggregateId
+     * @return null|object the cached aggregate root
+     */
+    public function get(AggregateType $aggregateType, $aggregateId);
+
+    /**
+     * Returns all aggregate roots of given type which are currently flagged as dirty
+     * The resulting array MUST be indexed by aggregate id.
+     *
+     * @param AggregateType $aggregateType
+     * @return array indexed by aggregate id
+     */
+    public function getAllDirtyAggregateRoots(AggregateType $aggregateType);
+
+    /**
+     * This method is called each time the repository has applied pending events to all dirty aggregate roots
+     * of the given type. So the identity map can remove the dirty flag for all effected aggregate roots.
+     *
+     * @param AggregateType $aggregateType
+     * @return void
+     */
+    public function cleanUp(AggregateType $aggregateType);
+}

--- a/src/Aggregate/InMemoryIdentityMap.php
+++ b/src/Aggregate/InMemoryIdentityMap.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ * This file is part of the prooph/event-store.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 10/7/15 - 11:01 PM
+ */
+namespace Prooph\EventStore\Aggregate;
+
+/**
+ * Class InMemoryIdentityMap
+ *
+ * This is the default IdentityMap used by the AggregateRepository if no other implementation was injected.
+ * It just organizes aggregate roots in internal array maps and keep them in memory.
+ *
+ * @package Prooph\EventStore\Aggregate
+ */
+final class InMemoryIdentityMap implements IdentityMap
+{
+    /**
+     * @var array
+     */
+    private $persistentMap = [];
+
+    /**
+     * @var array
+     */
+    private $dirtyMap = [];
+
+    /**
+     * Add aggregate root to the identity map
+     * The aggregate root MUST be flagged as dirty
+     * so that {@method getAllDirtyAggregateRoots} returns the AR
+     * as long as {@method cleanUp} is not called
+     *
+     * @param AggregateType $aggregateType
+     * @param string $aggregateId
+     * @param object $aggregateRoot
+     * @return void
+     */
+    public function add(AggregateType $aggregateType, $aggregateId, $aggregateRoot)
+    {
+        $this->dirtyMap[$aggregateType->toString()][$aggregateId]
+            = $this->persistentMap[$aggregateType->toString()][$aggregateId]
+            = $aggregateRoot;
+    }
+
+    /**
+     * Returns true if it has an aggregate root in the identity map
+     *
+     * @param AggregateType $aggregateType
+     * @param string $aggregateId
+     * @return bool
+     */
+    public function has(AggregateType $aggregateType, $aggregateId)
+    {
+        return isset($this->persistentMap[$aggregateType->toString()][$aggregateId]);
+    }
+
+    /**
+     * Get the aggregate root if it exists otherwise null
+     * The returned aggregate root MUST be flagged as dirty internally
+     * so that {@method getAllDirtyAggregateRoots} returns the AR
+     * as long as {@method cleanUp} is not called
+     *
+     * @param AggregateType $aggregateType
+     * @param string $aggregateId
+     * @return null|object the cached aggregate root
+     */
+    public function get(AggregateType $aggregateType, $aggregateId)
+    {
+        if (! $this->has($aggregateType, $aggregateId)) {
+            return;
+        }
+
+        return $this->dirtyMap[$aggregateType->toString()][$aggregateId]
+            = $this->persistentMap[$aggregateType->toString()][$aggregateId];
+    }
+
+    /**
+     * Returns all aggregate roots of given type which are currently flagged as dirty
+     * The resulting array MUST be indexed by aggregate id.
+     *
+     * @param AggregateType $aggregateType
+     * @return array indexed by aggregate id
+     */
+    public function getAllDirtyAggregateRoots(AggregateType $aggregateType)
+    {
+        return isset($this->dirtyMap[$aggregateType->toString()])
+            ? $this->dirtyMap[$aggregateType->toString()] : [];
+    }
+
+    /**
+     * This method is called each time the repository has applied pending events to all dirty aggregate roots
+     * of the given type. So the identity map can remove the dirty flag for all effected aggregate roots.
+     *
+     * @param AggregateType $aggregateType
+     * @return void
+     */
+    public function cleanUp(AggregateType $aggregateType)
+    {
+        unset($this->dirtyMap[$aggregateType->toString()]);
+    }
+}

--- a/tests/Aggregate/AggregateTypeTest.php
+++ b/tests/Aggregate/AggregateTypeTest.php
@@ -12,6 +12,8 @@
 namespace Prooph\EventStore\Aggregate;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Prooph\EventStoreTest\Mock\Post;
+use Prooph\EventStoreTest\Mock\User;
 
 /**
  * Class AggregateTypeTest
@@ -70,6 +72,36 @@ class AggregateTypeTest extends TestCase
     public function it_throws_exception_when_trying_to_create_from_empty_string()
     {
         AggregateType::fromString(null);
+    }
+
+    /**
+     * @test
+     */
+    public function it_asserts_correct_aggregate_type()
+    {
+        $aggregateType = AggregateType::fromAggregateRootClass(User::class);
+
+        $aggregateRoot = $this->prophesize(AggregateTypeProvider::class);
+
+        $aggregateRoot->aggregateType()->willReturn(AggregateType::fromAggregateRootClass(User::class));
+
+        $aggregateType->assert($aggregateRoot->reveal());
+    }
+
+    /**
+     * @test
+     * @expectedException Prooph\EventStore\Aggregate\Exception\AggregateTypeException
+     * @expectedExceptionMessage Aggregate types must be equal. Prooph\EventStoreTest\Mock\User != Prooph\EventStoreTest\Mock\Post
+     */
+    public function it_throws_exception_if_type_is_not_correct()
+    {
+        $aggregateType = AggregateType::fromAggregateRootClass(User::class);
+
+        $aggregateRoot = $this->prophesize(AggregateTypeProvider::class);
+
+        $aggregateRoot->aggregateType()->willReturn(AggregateType::fromAggregateRootClass(Post::class));
+
+        $aggregateType->assert($aggregateRoot->reveal());
     }
 
     /**

--- a/tests/Aggregate/InMemoryIdentityMapTest.php
+++ b/tests/Aggregate/InMemoryIdentityMapTest.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * This file is part of the prooph/event-store.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 10/8/15 - 10:14 AM
+ */
+namespace Prooph\EventStore\Aggregate;
+
+use Prooph\EventStoreTest\Mock\User;
+use Prooph\EventStoreTest\TestCase;
+
+final class InMemoryIdentityMapTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_adds_aggregate_root_to_identity_map_and_flags_it_as_dirty_as_long_as_clean_up_is_not_called()
+    {
+        $identityMap = new InMemoryIdentityMap();
+
+        $aggregateRoot = $this->prophesize(User::class);
+
+        $aggregateType = AggregateType::fromAggregateRoot($aggregateRoot->reveal());
+
+        $identityMap->add($aggregateType, '1', $aggregateRoot->reveal());
+
+        $this->assertTrue($identityMap->has($aggregateType, '1'));
+
+        $this->assertSame($aggregateRoot->reveal(), $identityMap->get($aggregateType, '1'));
+
+        $dirtyAggregates = $identityMap->getAllDirtyAggregateRoots($aggregateType);
+
+        $this->assertEquals(1, count($dirtyAggregates));
+
+        $this->assertSame($aggregateRoot->reveal(), $dirtyAggregates['1']);
+
+        $identityMap->cleanUp($aggregateType);
+
+        $this->assertEquals(0, count($identityMap->getAllDirtyAggregateRoots($aggregateType)));
+    }
+
+    /**
+     * @test
+     */
+    public function it_flags_aggregate_root_as_dirty_again_when_it_is_fetched_from_identity_map()
+    {
+        $identityMap = new InMemoryIdentityMap();
+
+        $aggregateRoot = $this->prophesize(User::class);
+
+        $aggregateType = AggregateType::fromAggregateRoot($aggregateRoot->reveal());
+
+        $identityMap->add($aggregateType, '1', $aggregateRoot->reveal());
+
+        $identityMap->cleanUp($aggregateType);
+
+        $this->assertEquals(0, count($identityMap->getAllDirtyAggregateRoots($aggregateType)));
+
+        $this->assertTrue($identityMap->has($aggregateType, '1'));
+
+        $this->assertSame($aggregateRoot->reveal(), $identityMap->get($aggregateType, '1'));
+
+        $dirtyAggregates = $identityMap->getAllDirtyAggregateRoots($aggregateType);
+
+        $this->assertEquals(1, count($dirtyAggregates));
+
+        $this->assertSame($aggregateRoot->reveal(), $dirtyAggregates['1']);
+    }
+}

--- a/tests/Aggregate/InMemoryIdentityMapTest.php
+++ b/tests/Aggregate/InMemoryIdentityMapTest.php
@@ -70,4 +70,14 @@ final class InMemoryIdentityMapTest extends TestCase
 
         $this->assertSame($aggregateRoot->reveal(), $dirtyAggregates['1']);
     }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_if_aggregate_root_is_not_registered_in_the_identity_map()
+    {
+        $identityMap = new InMemoryIdentityMap();
+
+        $this->assertNull($identityMap->get(AggregateType::fromAggregateRootClass(User::class), '1'));
+    }
 }


### PR DESCRIPTION
This PR includes several changes:

- IdentityMap becomes a first-class object 
- `AggregateRepository::__construct` got a new (optional) parameter `IdentityMap $identityMap = null`
    - This allows injection of a custom identity map which is capable of caching and providing aggregate roots
    - This allows the user to use for example memcached to keep aggregates in memory between requests 
    - and/or inject an IdentityMap which can load aggregate roots from snapshots
- The AggregateRepository now asserts that an added aggregate root has the correct aggregate type
    - **BC break!**: In the past it was possible to inherit from a base class - let's say `User` and handle `SalesManager`, `Bookkeeper`, etc. with the same UserRepository. This is still possible but the base class needs to implement [AggregateTypeProvider](https://github.com/prooph/event-store/blob/master/src/Aggregate/AggregateTypeProvider.php) otherwise `UserRepository::addAggregateRoot($salesManager)` will fail. 