### PR TITLE
remove has-method from identity map

### DIFF
--- a/src/Aggregate/AggregateRepository.php
+++ b/src/Aggregate/AggregateRepository.php
@@ -184,8 +184,10 @@ class AggregateRepository
     {
         Assertion::string($aggregateId, 'AggregateId needs to be string');
 
-        if ($this->identityMap->has($this->aggregateType, $aggregateId)) {
-            return $this->identityMap->get($this->aggregateType, $aggregateId);
+        $aggregateRoot = $this->identityMap->get($this->aggregateType, $aggregateId);
+
+        if ($aggregateRoot) {
+            return $aggregateRoot;
         }
 
         $streamEvents = $this->streamStrategy->read($this->aggregateType, $aggregateId);

--- a/src/Aggregate/IdentityMap.php
+++ b/src/Aggregate/IdentityMap.php
@@ -67,4 +67,14 @@ interface IdentityMap
      * @return void
      */
     public function cleanUp(AggregateType $aggregateType);
+
+    /**
+     * Mark an aggregate root as dirty
+     *
+     * @param AggregateType $aggregateType
+     * @param string $aggregateId
+     * @param object $aggregateRoot
+     * @return void
+     */
+    public function markDirty(AggregateType $aggregateType, $aggregateId, $aggregateRoot);
 }

--- a/src/Aggregate/IdentityMap.php
+++ b/src/Aggregate/IdentityMap.php
@@ -39,15 +39,6 @@ interface IdentityMap
     public function add(AggregateType $aggregateType, $aggregateId, $aggregateRoot);
 
     /**
-     * Returns true if it has an aggregate root in the identity map
-     *
-     * @param AggregateType $aggregateType
-     * @param string $aggregateId
-     * @return bool
-     */
-    public function has(AggregateType $aggregateType, $aggregateId);
-
-    /**
      * Get the aggregate root if it exists otherwise null
      * The returned aggregate root MUST be flagged as dirty internally
      * so that {@method getAllDirtyAggregateRoots} returns the AR

--- a/src/Aggregate/InMemoryIdentityMap.php
+++ b/src/Aggregate/InMemoryIdentityMap.php
@@ -49,18 +49,6 @@ final class InMemoryIdentityMap implements IdentityMap
     }
 
     /**
-     * Returns true if it has an aggregate root in the identity map
-     *
-     * @param AggregateType $aggregateType
-     * @param string $aggregateId
-     * @return bool
-     */
-    public function has(AggregateType $aggregateType, $aggregateId)
-    {
-        return isset($this->persistentMap[$aggregateType->toString()][$aggregateId]);
-    }
-
-    /**
      * Get the aggregate root if it exists otherwise null
      * The returned aggregate root MUST be flagged as dirty internally
      * so that {@method getAllDirtyAggregateRoots} returns the AR
@@ -72,7 +60,7 @@ final class InMemoryIdentityMap implements IdentityMap
      */
     public function get(AggregateType $aggregateType, $aggregateId)
     {
-        if (! $this->has($aggregateType, $aggregateId)) {
+        if (! isset($this->persistentMap[$aggregateType->toString()][$aggregateId])) {
             return;
         }
 

--- a/src/Aggregate/InMemoryIdentityMap.php
+++ b/src/Aggregate/InMemoryIdentityMap.php
@@ -43,9 +43,9 @@ final class InMemoryIdentityMap implements IdentityMap
      */
     public function add(AggregateType $aggregateType, $aggregateId, $aggregateRoot)
     {
-        $this->dirtyMap[$aggregateType->toString()][$aggregateId]
-            = $this->persistentMap[$aggregateType->toString()][$aggregateId]
-            = $aggregateRoot;
+        $this->persistentMap[$aggregateType->toString()][$aggregateId] = $aggregateRoot;
+
+        $this->markDirty($aggregateType, $aggregateId, $aggregateRoot);
     }
 
     /**
@@ -60,12 +60,15 @@ final class InMemoryIdentityMap implements IdentityMap
      */
     public function get(AggregateType $aggregateType, $aggregateId)
     {
-        if (! isset($this->persistentMap[$aggregateType->toString()][$aggregateId])) {
+        if (!isset($this->persistentMap[$aggregateType->toString()][$aggregateId])) {
             return;
         }
 
-        return $this->dirtyMap[$aggregateType->toString()][$aggregateId]
-            = $this->persistentMap[$aggregateType->toString()][$aggregateId];
+        $aggregateRoot = $this->persistentMap[$aggregateType->toString()][$aggregateId];
+
+        $this->markDirty($aggregateType, $aggregateId, $aggregateRoot);
+
+        return $aggregateRoot;
     }
 
     /**
@@ -91,5 +94,18 @@ final class InMemoryIdentityMap implements IdentityMap
     public function cleanUp(AggregateType $aggregateType)
     {
         unset($this->dirtyMap[$aggregateType->toString()]);
+    }
+
+    /**
+     * Mark an aggregate root as dirty
+     *
+     * @param AggregateType $aggregateType
+     * @param string $aggregateId
+     * @param object $aggregateRoot
+     * @return void
+     */
+    public function markDirty(AggregateType $aggregateType, $aggregateId, $aggregateRoot)
+    {
+        $this->dirtyMap[$aggregateType->toString()][$aggregateId] = $aggregateRoot;
     }
 }

--- a/tests/Aggregate/InMemoryIdentityMapTest.php
+++ b/tests/Aggregate/InMemoryIdentityMapTest.php
@@ -28,7 +28,7 @@ final class InMemoryIdentityMapTest extends TestCase
 
         $identityMap->add($aggregateType, '1', $aggregateRoot->reveal());
 
-        $this->assertTrue($identityMap->has($aggregateType, '1'));
+        $this->assertTrue((bool) $identityMap->get($aggregateType, '1'));
 
         $this->assertSame($aggregateRoot->reveal(), $identityMap->get($aggregateType, '1'));
 
@@ -60,7 +60,7 @@ final class InMemoryIdentityMapTest extends TestCase
 
         $this->assertEquals(0, count($identityMap->getAllDirtyAggregateRoots($aggregateType)));
 
-        $this->assertTrue($identityMap->has($aggregateType, '1'));
+        $this->assertTrue((bool) $identityMap->get($aggregateType, '1'));
 
         $this->assertSame($aggregateRoot->reveal(), $identityMap->get($aggregateType, '1'));
 


### PR DESCRIPTION
The has method must be removed from the identity map.

1) It's not needed.
2) When using non-in-memory-identity-maps this will lead to 2 queries, but one is sufficient.