### PR TITLE
Allow metadatas to be empty

### DIFF
--- a/src/EventStore.php
+++ b/src/EventStore.php
@@ -271,7 +271,7 @@ class EventStore
 
         if (null === $metadatas) {
             $metadatas = [];
-            foreach($streamNames as $streamName) {
+            foreach ($streamNames as $streamName) {
                 $metadatas[] = [];
             }
         }

--- a/src/EventStore.php
+++ b/src/EventStore.php
@@ -259,14 +259,21 @@ class EventStore
     /**
      * @param StreamName[] $streamNames
      * @param DateTimeInterface|null $since
-     * @param array $metadatas One metadata array per stream name, same index order is required
+     * @param null|array $metadatas One metadata array per stream name, same index order is required
      * @return CompositeIterator
      * @throws Exception\InvalidArgumentException
      */
-    public function replay(array $streamNames, DateTimeInterface $since = null, array $metadatas)
+    public function replay(array $streamNames, DateTimeInterface $since = null, array $metadatas = null)
     {
         if (empty($streamNames)) {
             throw new Exception\InvalidArgumentException('No stream names given');
+        }
+
+        if (null === $metadatas) {
+            $metadatas = [];
+            foreach($streamNames as $streamName) {
+                $metadatas[] = [];
+            }
         }
 
         if (count($streamNames) !== count($metadatas)) {

--- a/tests/EventStoreTest.php
+++ b/tests/EventStoreTest.php
@@ -660,7 +660,7 @@ class EventStoreTest extends TestCase
         $this->eventStore->appendTo(new StreamName('user'), new ArrayIterator([$streamEvent2]));
         $this->eventStore->commit();
 
-        $iterator = $this->eventStore->replay([new StreamName('user'), new StreamName('post')], null, [[], []]);
+        $iterator = $this->eventStore->replay([new StreamName('user'), new StreamName('post')]);
 
         $count = 0;
         foreach ($iterator as $key => $event) {
@@ -717,7 +717,7 @@ class EventStoreTest extends TestCase
         $this->eventStore->appendTo(new StreamName('user'), new ArrayIterator([$streamEvent2]));
         $this->eventStore->commit();
 
-        $iterator = $this->eventStore->replay([new StreamName('user'), new StreamName('post')], $now, [[], []]);
+        $iterator = $this->eventStore->replay([new StreamName('user'), new StreamName('post')], $now);
 
         $count = 0;
         foreach ($iterator as $key => $event) {
@@ -772,7 +772,7 @@ class EventStoreTest extends TestCase
         $this->eventStore->appendTo(new StreamName('user'), new ArrayIterator([$streamEvent2]));
         $this->eventStore->commit();
 
-        $iterator = $this->eventStore->replay([new StreamName('user'), new StreamName('post')], null, [[], []]);
+        $iterator = $this->eventStore->replay([new StreamName('user'), new StreamName('post')]);
 
         $count = 0;
         foreach ($iterator as $key => $event) {


### PR DESCRIPTION
While writing docs I recognized that the signature of `EventStore::replay` is a bit confusing. The second parameter `$since` is optional but the third one needs to be given again. My first idea was to flip the parameters but then I thought it would also be a good idea to turn `$metadatas` into an optional parameter, too. @prolic Let me know what you think about the change.