### PR TITLE
Use event store FQCN as service id

### DIFF
--- a/docs/event_store.md
+++ b/docs/event_store.md
@@ -101,7 +101,7 @@ If the requirements are met you just need to add a new section in your applicati
 ]
 ```
 
-... and register the factory in your IoC container. We recommend using the service id `prooph.event_store` for the event store
+... and register the factory in your IoC container. We recommend using the service id `Prooph\EventStore\EventStore (EventStore::class)` for the event store
 because other factories like the [stream factories](../src/Container/Stream) try to locate the event store
 by using this service id.
 

--- a/src/Container/Stream/AggregateStreamStrategyFactory.php
+++ b/src/Container/Stream/AggregateStreamStrategyFactory.php
@@ -12,6 +12,7 @@
 namespace Prooph\EventStore\Container\Stream;
 
 use Interop\Container\ContainerInterface;
+use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Stream\AggregateStreamStrategy;
 
 /**
@@ -36,6 +37,6 @@ final class AggregateStreamStrategyFactory
             }
         }
 
-        return new AggregateStreamStrategy($container->get('prooph.event_store'), $aggregateTypeStreamMap);
+        return new AggregateStreamStrategy($container->get(EventStore::class), $aggregateTypeStreamMap);
     }
 }

--- a/src/Container/Stream/AggregateTypeStreamStrategyFactory.php
+++ b/src/Container/Stream/AggregateTypeStreamStrategyFactory.php
@@ -12,6 +12,7 @@
 namespace Prooph\EventStore\Container\Stream;
 
 use Interop\Container\ContainerInterface;
+use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Stream\AggregateTypeStreamStrategy;
 
 /**
@@ -36,6 +37,6 @@ final class AggregateTypeStreamStrategyFactory
             }
         }
 
-        return new AggregateTypeStreamStrategy($container->get('prooph.event_store'), $aggregateTypeStreamMap);
+        return new AggregateTypeStreamStrategy($container->get(EventStore::class), $aggregateTypeStreamMap);
     }
 }

--- a/src/Container/Stream/SingleStreamStrategyFactory.php
+++ b/src/Container/Stream/SingleStreamStrategyFactory.php
@@ -12,6 +12,7 @@
 namespace Prooph\EventStore\Container\Stream;
 
 use Interop\Container\ContainerInterface;
+use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Stream\SingleStreamStrategy;
 
 /**
@@ -36,6 +37,6 @@ final class SingleStreamStrategyFactory
             }
         }
 
-        return new SingleStreamStrategy($container->get('prooph.event_store'), $singleStreamName);
+        return new SingleStreamStrategy($container->get(EventStore::class), $singleStreamName);
     }
 }

--- a/tests/Container/Stream/AggregateStreamStrategyFactoryTest.php
+++ b/tests/Container/Stream/AggregateStreamStrategyFactoryTest.php
@@ -32,7 +32,7 @@ class AggregateStreamStrategyFactoryTest extends TestCase
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
         $containerMock->expects($this->once())->method('has')->with('config')->willReturn(false);
-        $containerMock->expects($this->once())->method('get')->with('prooph.event_store')->willReturn($eventStoreMock);
+        $containerMock->expects($this->once())->method('get')->with(EventStore::class)->willReturn($eventStoreMock);
 
         $factory = new AggregateStreamStrategyFactory();
         $streamStrategy = $factory($containerMock);
@@ -52,7 +52,7 @@ class AggregateStreamStrategyFactoryTest extends TestCase
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
         $containerMock->expects($this->at(0))->method('has')->with('config')->willReturn(true);
         $containerMock->expects($this->at(1))->method('get')->with('config')->willReturn($config);
-        $containerMock->expects($this->at(2))->method('get')->with('prooph.event_store')->willReturn($eventStoreMock);
+        $containerMock->expects($this->at(2))->method('get')->with(EventStore::class)->willReturn($eventStoreMock);
 
         $factory = new AggregateStreamStrategyFactory();
         $streamStrategy = $factory($containerMock);

--- a/tests/Container/Stream/AggregateTypeStreamStrategyFactoryTest.php
+++ b/tests/Container/Stream/AggregateTypeStreamStrategyFactoryTest.php
@@ -32,7 +32,7 @@ class AggregateTypeStreamStrategyFactoryTest extends TestCase
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
         $containerMock->expects($this->once())->method('has')->with('config')->willReturn(false);
-        $containerMock->expects($this->once())->method('get')->with('prooph.event_store')->willReturn($eventStoreMock);
+        $containerMock->expects($this->once())->method('get')->with(EventStore::class)->willReturn($eventStoreMock);
 
         $factory = new AggregateTypeStreamStrategyFactory();
         $streamStrategy = $factory($containerMock);
@@ -52,7 +52,7 @@ class AggregateTypeStreamStrategyFactoryTest extends TestCase
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
         $containerMock->expects($this->at(0))->method('has')->with('config')->willReturn(true);
         $containerMock->expects($this->at(1))->method('get')->with('config')->willReturn($config);
-        $containerMock->expects($this->at(2))->method('get')->with('prooph.event_store')->willReturn($eventStoreMock);
+        $containerMock->expects($this->at(2))->method('get')->with(EventStore::class)->willReturn($eventStoreMock);
 
         $factory = new AggregateTypeStreamStrategyFactory();
         $streamStrategy = $factory($containerMock);

--- a/tests/Container/Stream/SingleStreamStrategyFactoryTest.php
+++ b/tests/Container/Stream/SingleStreamStrategyFactoryTest.php
@@ -32,7 +32,7 @@ class SingleStreamStrategyFactoryTest extends TestCase
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
         $containerMock->expects($this->once())->method('has')->with('config')->willReturn(false);
-        $containerMock->expects($this->once())->method('get')->with('prooph.event_store')->willReturn($eventStoreMock);
+        $containerMock->expects($this->once())->method('get')->with(EventStore::class)->willReturn($eventStoreMock);
 
         $factory = new SingleStreamStrategyFactory();
         $streamStrategy = $factory($containerMock);
@@ -52,7 +52,7 @@ class SingleStreamStrategyFactoryTest extends TestCase
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
         $containerMock->expects($this->at(0))->method('has')->with('config')->willReturn(true);
         $containerMock->expects($this->at(1))->method('get')->with('config')->willReturn($config);
-        $containerMock->expects($this->at(2))->method('get')->with('prooph.event_store')->willReturn($eventStoreMock);
+        $containerMock->expects($this->at(2))->method('get')->with(EventStore::class)->willReturn($eventStoreMock);
 
         $factory = new SingleStreamStrategyFactory();
         $streamStrategy = $factory($containerMock);


### PR DESCRIPTION
Normally there should only be one event store instance per application / context so we can use the FQCN as service id instead of the string `prooph.event_store`