### PR TITLE
Replay not apply

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -56,7 +56,7 @@ Let's have a look at the constructor
  * @param null|string   $identifierMethodName
  * @param null|string   $versionMethodName
  * @param null|string   $popRecordedEventsMethodName
- * @param null|string   $applyEventsMethodsName
+ * @param null|string   $replayEventsMethodsName
  * @param null|string   $staticReconstituteFromHistoryMethodName
  * @param null|callable $eventToMessageCallback
  * @param null|callable $messageToEventCallback
@@ -65,7 +65,7 @@ public function __construct(
     $identifierMethodName = null,
     $versionMethodName = null,
     $popRecordedEventsMethodName = null,
-    $applyEventsMethodsName = null,
+    $replayEventsMethodsName = null,
     $staticReconstituteFromHistoryMethodName = null,
     $eventToMessageCallback = null,
     $messageToEventCallback = null)
@@ -87,9 +87,9 @@ We can identify 7 dependencies but all are optional.
   - defaults to `popRecordedEvents`
   - with this method the `ConfigurableAggregateTranslator` requests the latest recorded events from your aggregate
   - the aggregate should also clear its internal event cache before returning the events as no additional method is invoked to do so
-- `applyStreamEvents`
-  - defaults to `apply`
-  - used in case the repository loaded a snapshot and needs to apply newer events
+- `replayStreamEvents`
+  - defaults to `replay`
+  - used in case the repository loaded a snapshot and needs to replay newer events
 - `$staticReconstituteFromHistoryMethodName`
   - defaults to `reconstituteFromHistory`
   - like indicated in the parameter name the referenced method must be static (a named constructor) which must return an instance of the aggregate with all events replayed

--- a/src/Aggregate/AggregateRepository.php
+++ b/src/Aggregate/AggregateRepository.php
@@ -231,7 +231,7 @@ class AggregateRepository
             return $aggregateRoot;
         }
 
-        $this->aggregateTranslator->applyStreamEvents($aggregateRoot, $streamEvents);
+        $this->aggregateTranslator->replayStreamEvents($aggregateRoot, $streamEvents);
 
         return $aggregateRoot;
     }

--- a/src/Aggregate/AggregateTranslator.php
+++ b/src/Aggregate/AggregateTranslator.php
@@ -51,5 +51,5 @@ interface AggregateTranslator
      * @param $anEventSourcedAggregateRoot
      * @param Iterator $events
      */
-    public function applyStreamEvents($anEventSourcedAggregateRoot, Iterator $events);
+    public function replayStreamEvents($anEventSourcedAggregateRoot, Iterator $events);
 }

--- a/tests/Aggregate/ConfigurableAggregateTranslatorTest.php
+++ b/tests/Aggregate/ConfigurableAggregateTranslatorTest.php
@@ -201,7 +201,7 @@ final class ConfigurableAggregateTranslatorTest extends TestCase
 
         $translator = new ConfigurableAggregateTranslator(null, null, null, 'unknownMethod');
 
-        $translator->applyStreamEvents($ar->reveal(), new \ArrayIterator([]));
+        $translator->replayStreamEvents($ar->reveal(), new \ArrayIterator([]));
     }
 
     /**
@@ -229,7 +229,7 @@ final class ConfigurableAggregateTranslatorTest extends TestCase
 
         $translator = new ConfigurableAggregateTranslator();
 
-        $translator->applyStreamEvents($ar->reveal(), new \ArrayIterator([new \stdClass()]));
+        $translator->replayStreamEvents($ar->reveal(), new \ArrayIterator([new \stdClass()]));
     }
 
     /**
@@ -255,7 +255,7 @@ final class ConfigurableAggregateTranslatorTest extends TestCase
     /**
      * @test
      */
-    public function it_invokes_message_to_event_callback_for_each_event_applying()
+    public function it_invokes_message_to_event_callback_for_each_event_replaying()
     {
         $message = $this->prophesize(Message::class);
 
@@ -263,13 +263,13 @@ final class ConfigurableAggregateTranslatorTest extends TestCase
 
         $dummyEvent = new \stdClass();
 
-        $ar->apply($dummyEvent)->shouldBeCalled(2);
+        $ar->replay($dummyEvent)->shouldBeCalled(2);
 
         $translator = new ConfigurableAggregateTranslator(null, null, null, null, null, null, function (Message $message) use ($dummyEvent) {
             return $dummyEvent;
         });
 
-        $translator->applyStreamEvents($ar->reveal(), new \ArrayIterator([$message->reveal(), $message->reveal()]));
+        $translator->replayStreamEvents($ar->reveal(), new \ArrayIterator([$message->reveal(), $message->reveal()]));
     }
 
     /**
@@ -399,7 +399,7 @@ final class ConfigurableAggregateTranslatorTest extends TestCase
     public function it_fails_on_applying_pending_stream_events_when_event_sourced_aggregate_root_is_not_an_object()
     {
         $translator = new ConfigurableAggregateTranslator();
-        $translator->applyStreamEvents('invalid', new \ArrayIterator([]));
+        $translator->replayStreamEvents('invalid', new \ArrayIterator([]));
     }
 
     /**

--- a/tests/Mock/DefaultAggregateRoot.php
+++ b/tests/Mock/DefaultAggregateRoot.php
@@ -73,7 +73,7 @@ final class DefaultAggregateRoot implements DefaultAggregateRootContract
     /**
      * @param $event
      */
-    public function apply($event)
+    public function replay($event)
     {
         // not required for this mock
     }

--- a/tests/Mock/DefaultAggregateRootContract.php
+++ b/tests/Mock/DefaultAggregateRootContract.php
@@ -45,5 +45,5 @@ interface DefaultAggregateRootContract
     /**
      * @param $event
      */
-    public function apply($event);
+    public function replay($event);
 }

--- a/tests/Mock/FaultyAggregateRoot.php
+++ b/tests/Mock/FaultyAggregateRoot.php
@@ -58,7 +58,7 @@ final class FaultyAggregateRoot implements DefaultAggregateRootContract
     /**
      * @param $event
      */
-    public function apply($event)
+    public function replay($event)
     {
         // faulty method
         return;

--- a/tests/Mock/User.php
+++ b/tests/Mock/User.php
@@ -167,7 +167,7 @@ class User
     /**
      * @param DomainEvent[] $streamEvents
      */
-    private function replay($streamEvents)
+    public function replay($streamEvents)
     {
         foreach ($streamEvents as $streamEvent) {
             $this->apply($streamEvent);


### PR DESCRIPTION
This PR fixes a problem encountered while trying the snapshot feature. If the repository loads an AR from snapshot store and then newer events from the event store these newer events need to be replayed because the AR must update its version internally. When applying events the AR does not update its version.