### PR TITLE
Rewind stream events when creating a stream

### DIFF
--- a/src/Adapter/InMemoryAdapter.php
+++ b/src/Adapter/InMemoryAdapter.php
@@ -93,6 +93,9 @@ class InMemoryAdapter implements Adapter
             return new Stream($streamName, new \ArrayIterator($filteredEvents));
         }
 
+        //Rewind before returning cached iterator as event store uses Iterator::valid()
+        //to test if stream contains events
+        $streamEvents->rewind();
         return new Stream($streamName, $streamEvents);
     }
 

--- a/src/Adapter/InMemoryAdapter.php
+++ b/src/Adapter/InMemoryAdapter.php
@@ -39,7 +39,9 @@ class InMemoryAdapter implements Adapter
      */
     public function create(Stream $stream)
     {
-        $this->streams[$stream->streamName()->toString()] = $stream->streamEvents();
+        $streamEvents = $stream->streamEvents();
+        $streamEvents->rewind();
+        $this->streams[$stream->streamName()->toString()] = $streamEvents;
     }
 
     /**


### PR DESCRIPTION
Small bugfix for InMemoryAdapter. When creating a new stream the recorded stream events iterator must be rewind as otherwise a later call to `$streamEvents->valid()` will be false