### PR TITLE
Upgrade depencency to ramsey/uuid 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "~5.5|~7.0",
-        "ramsey/uuid" : "~2.8",
+        "ramsey/uuid" : "~2.8|~3.0",
         "beberlei/assert": "~2.3",
         "prooph/common" : "~3.3"
     },

--- a/tests/Mock/Post.php
+++ b/tests/Mock/Post.php
@@ -13,7 +13,7 @@ namespace ProophTest\EventStore\Mock;
 
 use Prooph\Common\Messaging\DomainEvent;
 use Prooph\Common\Messaging\Message;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Class Post

--- a/tests/Mock/User.php
+++ b/tests/Mock/User.php
@@ -13,7 +13,7 @@ namespace ProophTest\EventStore\Mock;
 
 use Prooph\Common\Messaging\DomainEvent;
 use Prooph\Common\Messaging\Message;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Class User


### PR DESCRIPTION
This change bases the existing code on the 3.x version of ramsey/uuid (previously called rhumsaa/uuid) in order to avoid conflicts with third-party libraries which require version 3.0 or higher.