### PR TITLE
update factories to interop-config 1.0, add static factory support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,8 @@
         "DDD",
         "prooph"
     ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": "~5.5|~7.0",
         "ramsey/uuid" : "~2.8",
@@ -29,12 +31,12 @@
     },
     "require-dev": {
         "container-interop/container-interop": "^1.1",
-        "sandrokeil/interop-config": "^0.3.1",
+        "sandrokeil/interop-config": "^1.0",
         "phpunit/phpunit": "~4.8",
         "fabpot/php-cs-fixer": "1.7.*",
         "satooshi/php-coveralls": "^1.0",
         "zendframework/zend-servicemanager": "~2.6",
-        "tobiju/bookdown-bootswatch-templates": "^0.2.0"
+        "tobiju/bookdown-bootswatch-templates": "^1.0"
     },
     "suggest" : {
         "prooph/event-sourcing" : "Basic functionality for event sourced aggregates",
@@ -48,6 +50,9 @@
         "prooph/snapshot-memcached-adapter": "For usage with memcached as snapshot adapter",
         "prooph/snapshot-mongodb-adapter": "For usage with mongodb as snapshot adapter"
     },
+    "conflict": {
+        "sandrokeil/interop-config": "<1.0"
+    },
     "autoload": {
         "psr-4": {
             "Prooph\\EventStore\\": "src/"
@@ -57,5 +62,14 @@
         "psr-4": {
             "ProophTest\\EventStore\\": "tests/"
         }
+    },
+    "scripts": {
+        "check": [
+            "@cs",
+            "@test"
+        ],
+        "cs": "php-cs-fixer fix -v --diff --dry-run",
+        "cs-fix": "php-cs-fixer fix -v --diff",
+        "test": "phpunit"
     }
 }

--- a/src/Container/Aggregate/AbstractAggregateRepositoryFactory.php
+++ b/src/Container/Aggregate/AbstractAggregateRepositoryFactory.php
@@ -10,83 +10,18 @@
  */
 namespace Prooph\EventStore\Container\Aggregate;
 
-use Interop\Config\ConfigurationTrait;
-use Interop\Config\RequiresContainerId;
-use Interop\Config\RequiresMandatoryOptions;
-use Interop\Container\ContainerInterface;
-use Prooph\EventStore\Aggregate\AggregateRepository;
-use Prooph\EventStore\Aggregate\AggregateType;
-use Prooph\EventStore\EventStore;
-use Prooph\EventStore\Exception\ConfigurationException;
-use Prooph\EventStore\Stream\StreamName;
-
 /**
- * Class AbstractAggregateRepositoryFactory
- *
- * @package Prooph\EventStore\Container
+ * @deprecated Use AggregateRepositoryFactory, will be removed in next major version
  */
-abstract class AbstractAggregateRepositoryFactory implements RequiresContainerId, RequiresMandatoryOptions
+abstract class AbstractAggregateRepositoryFactory extends AggregateRepositoryFactory
 {
-    use ConfigurationTrait;
-
-    /**
-     * @param ContainerInterface $container
-     * @throws ConfigurationException
-     * @return AggregateRepository
-     */
-    public function __invoke(ContainerInterface $container)
+    public function __construct()
     {
-        $config = $container->get('config');
-        $config = $this->options($config);
-
-        $repositoryClass = $config['repository_class'];
-
-        if (! class_exists($repositoryClass)) {
-            throw ConfigurationException::configurationError(sprintf('Repository class %s cannot be found', $repositoryClass));
-        }
-
-        if (! is_subclass_of($repositoryClass, AggregateRepository::class)) {
-            throw ConfigurationException::configurationError(sprintf('Repository class %s must be a sub class of %s', $repositoryClass, AggregateRepository::class));
-        }
-
-        $eventStore = $container->get(EventStore::class);
-        $aggregateType = AggregateType::fromAggregateRootClass($config['aggregate_type']);
-        $aggregateTranslator = $container->get($config['aggregate_translator']);
-
-        $snapshotStore = isset($config['snapshot_store'])? $container->get($config['snapshot_store']) : null;
-
-        $streamName = isset($config['stream_name'])? new StreamName($config['stream_name']) : null;
-
-        $oneStreamPerAggregate = isset($config['one_stream_per_aggregate'])? (bool)$config['one_stream_per_aggregate'] : false;
-
-        return new $repositoryClass($eventStore, $aggregateType, $aggregateTranslator, $snapshotStore, $streamName, $oneStreamPerAggregate);
+        parent::__construct($this->containerId());
     }
 
     /**
      * @inheritdoc
      */
-    public function vendorName()
-    {
-        return 'prooph';
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function packageName()
-    {
-        return 'event_store';
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function mandatoryOptions()
-    {
-        return [
-            'repository_class',
-            'aggregate_type',
-            'aggregate_translator',
-        ];
-    }
+    abstract public function containerId();
 }

--- a/src/Container/Aggregate/AggregateRepositoryFactory.php
+++ b/src/Container/Aggregate/AggregateRepositoryFactory.php
@@ -1,0 +1,126 @@
+<?php
+/*
+ * This file is part of the prooph/event-store.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 10/21/15 - 6:10 PM
+ */
+namespace Prooph\EventStore\Container\Aggregate;
+
+use Interop\Config\ConfigurationTrait;
+use Interop\Config\RequiresConfigId;
+use Interop\Config\RequiresMandatoryOptions;
+use Interop\Container\ContainerInterface;
+use Prooph\EventStore\Aggregate\AggregateRepository;
+use Prooph\EventStore\Aggregate\AggregateType;
+use Prooph\EventStore\Aggregate\Exception\InvalidArgumentException;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Exception\ConfigurationException;
+use Prooph\EventStore\Stream\StreamName;
+
+/**
+ * Creates aggregate repository classes
+ *
+ * Don't extend from this class! in next major version this class will be final.
+ */
+class AggregateRepositoryFactory implements RequiresConfigId, RequiresMandatoryOptions
+{
+    use ConfigurationTrait;
+
+    /**
+     * @var string
+     */
+    private $configId;
+
+    /**
+     * Creates a new instance from a specified config, specifically meant to be used as static factory.
+     *
+     * In case you want to use another config key than provided by the factories, you can add the following factory to
+     * your config:
+     *
+     * <code>
+     * <?php
+     * return [
+     *     'your_aggregate_class' => [AggregateRepositoryFactory::class, 'your_aggregate_class'],
+     * ];
+     * </code>
+     *
+     * @param string $name
+     * @param array $arguments
+     * @return mixed
+     * @throws InvalidArgumentException
+     */
+    public static function __callStatic($name, array $arguments)
+    {
+        if (!isset($arguments[0]) || !$arguments[0] instanceof ContainerInterface) {
+            throw new InvalidArgumentException(
+                sprintf('The first argument must be of type %s', ContainerInterface::class)
+            );
+        }
+        return (new static($name))->__invoke($arguments[0]);
+    }
+
+    /**
+     * @param string $configId
+     */
+    public function __construct($configId)
+    {
+        $this->configId = $configId;
+    }
+
+    /**
+     * @param ContainerInterface $container
+     * @throws ConfigurationException
+     * @return AggregateRepository
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        $config = $container->get('config');
+        $config = $this->options($config, $this->configId);
+
+        $repositoryClass = $config['repository_class'];
+
+        if (! class_exists($repositoryClass)) {
+            throw ConfigurationException::configurationError(sprintf('Repository class %s cannot be found', $repositoryClass));
+        }
+
+        if (! is_subclass_of($repositoryClass, AggregateRepository::class)) {
+            throw ConfigurationException::configurationError(sprintf('Repository class %s must be a sub class of %s', $repositoryClass, AggregateRepository::class));
+        }
+
+        $eventStore = $container->get(EventStore::class);
+        $aggregateType = AggregateType::fromAggregateRootClass($config['aggregate_type']);
+        $aggregateTranslator = $container->get($config['aggregate_translator']);
+
+        $snapshotStore = isset($config['snapshot_store'])? $container->get($config['snapshot_store']) : null;
+
+        $streamName = isset($config['stream_name'])? new StreamName($config['stream_name']) : null;
+
+        $oneStreamPerAggregate = isset($config['one_stream_per_aggregate'])? (bool)$config['one_stream_per_aggregate'] : false;
+
+        return new $repositoryClass($eventStore, $aggregateType, $aggregateTranslator, $snapshotStore, $streamName, $oneStreamPerAggregate);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function dimensions()
+    {
+        return ['prooph', 'event_store'];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function mandatoryOptions()
+    {
+        return [
+            'repository_class',
+            'aggregate_type',
+            'aggregate_translator',
+        ];
+    }
+}

--- a/src/Container/EventStoreFactory.php
+++ b/src/Container/EventStoreFactory.php
@@ -93,17 +93,9 @@ final class EventStoreFactory implements RequiresConfig, RequiresMandatoryOption
     /**
      * @inheritdoc
      */
-    public function vendorName()
+    public function dimensions()
     {
-        return 'prooph';
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function packageName()
-    {
-        return 'event_store';
+        return ['prooph', 'event_store'];
     }
 
     /**

--- a/src/Container/Snapshot/SnapshotStoreFactory.php
+++ b/src/Container/Snapshot/SnapshotStoreFactory.php
@@ -42,17 +42,9 @@ final class SnapshotStoreFactory implements RequiresConfig, RequiresMandatoryOpt
     /**
      * @inheritdoc
      */
-    public function vendorName()
+    public function dimensions()
     {
-        return 'prooph';
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function packageName()
-    {
-        return 'snapshot_store';
+        return ['prooph', 'snapshot_store'];
     }
 
     /**

--- a/tests/Container/Aggregate/AbstractAggregateRepositoryFactoryTest.php
+++ b/tests/Container/Aggregate/AbstractAggregateRepositoryFactoryTest.php
@@ -15,7 +15,6 @@ use Prooph\EventStore\Aggregate\AggregateTranslator;
 use Prooph\EventStore\Aggregate\AggregateType;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Snapshot\SnapshotStore;
-use Prooph\EventStore\Stream\StreamStrategy;
 use ProophTest\EventStore\Mock\FaultyRepositoryMock;
 use ProophTest\EventStore\Mock\RepositoryMock;
 use ProophTest\EventStore\Mock\RepositoryMockFactory;
@@ -149,8 +148,6 @@ class AbstractAggregateRepositoryFactoryTest extends TestCase
         $userTranslator = $this->prophesize(AggregateTranslator::class);
 
         $container->get('user_translator')->willReturn($userTranslator->reveal());
-
-        $streamStrategy = $this->prophesize(StreamStrategy::class);
 
         $snapshotStore = $this->prophesize(SnapshotStore::class);
         $container->has('ultra_fast_snapshot_store')->willReturn(true);

--- a/tests/Container/Aggregate/AggregateRepositoryFactoryTest.php
+++ b/tests/Container/Aggregate/AggregateRepositoryFactoryTest.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ * This file is part of the prooph/event-store.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 10/21/15 - 8:07 PM
+ */
+namespace ProophTest\EventStore\Container\Aggregate;
+
+use Interop\Container\ContainerInterface;
+use Prooph\EventStore\Aggregate\AggregateTranslator;
+use Prooph\EventStore\Aggregate\Exception\InvalidArgumentException;
+use Prooph\EventStore\Container\Aggregate\AggregateRepositoryFactory;
+use Prooph\EventStore\EventStore;
+use ProophTest\EventStore\Mock\RepositoryMock;
+use ProophTest\EventStore\Mock\User;
+use ProophTest\EventStore\TestCase;
+
+/**
+ * Main tests can be found in AbstractAggregateRepositoryFactoryTest
+ */
+class AggregateRepositoryFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_an_aggregate_from_static_call()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn([
+            'prooph' => [
+                'event_store' => [
+                    'repository_mock' => [
+                        'repository_class' => RepositoryMock::class,
+                        'aggregate_type' => User::class,
+                        'aggregate_translator' => 'user_translator',
+                    ]
+                ]
+            ]
+        ]);
+        $container->get(EventStore::class)->willReturn($this->eventStore);
+
+        $userTranslator = $this->prophesize(AggregateTranslator::class);
+
+        $container->get('user_translator')->willReturn($userTranslator->reveal());
+
+        $factory = [AggregateRepositoryFactory::class, 'repository_mock'];
+        self::assertInstanceOf(RepositoryMock::class, $factory($container->reveal()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_invalid_argument_exception_without_container_on_static_call()
+    {
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            'The first argument must be of type Interop\Container\ContainerInterface'
+        );
+        AggregateRepositoryFactory::other_config_id();
+    }
+}


### PR DESCRIPTION
This PR adds support for interop-config 1.0 and adds a new feature called static factories. Also dependencies are updated to latest versions and Composer scripts were added.

Note: We have some BC breaks of the factory methods because the interface of interop-config has changed. The `AbstractAggregateRepositoryFactory` was marked as deprecated, but no migration is required.