### PR TITLE
Move ramsey/uuid to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     ],
     "require": {
         "php": "~5.5|~7.0",
-        "ramsey/uuid" : "~2.8",
         "beberlei/assert": "~2.3",
         "prooph/common" : "~3.3"
     },
     "require-dev": {
         "container-interop/container-interop": "^1.1",
         "sandrokeil/interop-config": "^0.3.1",
+        "ramsey/uuid" : "~2.8",
         "phpunit/phpunit": "~4.8",
         "fabpot/php-cs-fixer": "1.7.*",
         "satooshi/php-coveralls": "^1.0",


### PR DESCRIPTION
As ramsey/uuid is currently being used only in tests it can be moved to require-dev