### PR TITLE
Fix/example array to iterator

### DIFF
--- a/examples/quickstart.php
+++ b/examples/quickstart.php
@@ -59,7 +59,7 @@ $eventStore->beginTransaction();
  */
 $streamName = new \Prooph\EventStore\Stream\StreamName('event_stream');
 
-$singleStream = new \Prooph\EventStore\Stream\Stream($streamName, []);
+$singleStream = new \Prooph\EventStore\Stream\Stream($streamName, new ArrayIterator([]));
 
 /**
  * As we are using the InMemoryAdapter we have to create the event stream
@@ -74,7 +74,7 @@ $eventStore->create($singleStream);
 /**
  * Now we can easily add events to the stream ...
  */
-$eventStore->appendTo($streamName, [$quickStartSucceeded /*, ...*/]);
+$eventStore->appendTo($streamName, new ArrayIterator([$quickStartSucceeded /*, ...*/]));
 
 /**
  * Next step would be to commit the transaction.

--- a/tests/Example/QuickstartTest.php
+++ b/tests/Example/QuickstartTest.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * This file is part of the prooph/event-store.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 8/22/15 - 9:42 PM
+ */
+
+namespace ProophTest\EventStore\Example;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Class QuickstartTest
+ *
+ * @package ProophTest\EventStore\Aggregate
+ * @author Alexander Miertsch <contact@prooph.de>
+ */
+class QuickstartTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function test_that_it_provides_the_correct_example_output()
+    {
+        $pattern = sprintf(
+            '~^Event with name Example\\\\Event\\\\QuickStartSucceeded was recorded\. It occurred on %s ///\n\nIt works$~',
+            '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
+        );
+
+        $this->assertRegExp($pattern, $this->getQuickstartOutput());
+    }
+
+    private function getQuickstartOutput()
+    {
+        ob_start();
+        include __DIR__ . '/../../examples/quickstart.php';
+        return ob_get_clean();
+    }
+}

--- a/tests/Example/QuickstartTest.php
+++ b/tests/Example/QuickstartTest.php
@@ -16,7 +16,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 /**
  * Class QuickstartTest
  *
- * @package ProophTest\EventStore\Aggregate
+ * @package ProophTest\EventStore\Example
  * @author Alexander Miertsch <contact@prooph.de>
  */
 class QuickstartTest extends TestCase


### PR DESCRIPTION
Prooph\EventStore\EventStore::appendTo and Prooph\EventStore\Stream\Stream::__construct
expect an Iterator, this wraps the arrays being passed to them in ArrayIterator.