### PR TITLE
add possibility to clear identity map manually

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -234,4 +234,24 @@ processes dealing with the same aggregate would run into concurrency issues very
 The test case has some more tests including snapshot usage and working with different stream names / strategies.
 Just browse through the test methods for details.
 
+## Loading of thousands aggregates
+If you need to load thousands of aggregates for reading only, your memory can be exhausted, because the 
+`AggregateRepository` uses an identity map. So every loaded aggregate is stored there, unless a commit is executed. If
+you have a read only process, you should consider to clear the identity map at sometime. This can be done by calling 
+`clearIdentityMap()`.
 
+```php
+$thousandsOfAggregateIds = [];
+$number = count($thousandsOfAggregateIds);
+
+foreach ($thousandsOfAggregateIds as $aggregateId) {
+    $aggregate = $this->repository->getAggregateRoot($aggregateId);
+
+    // do something with the aggregate data e.g. build read model
+
+    // clear on every 500th aggregate
+    if (0 === $number % 500) {
+        $this->repository->clearIdentityMap();
+    }
+}
+```

--- a/src/Aggregate/AggregateRepository.php
+++ b/src/Aggregate/AggregateRepository.php
@@ -200,6 +200,14 @@ class AggregateRepository
     }
 
     /**
+     * Empties the identity map. Use this if you load thousands of aggregates to free memory e.g. modulo 500.
+     */
+    public function clearIdentityMap() : void
+    {
+        $this->identityMap = [];
+    }
+
+    /**
      * @param string $aggregateId
      *
      * @return null|object

--- a/tests/Aggregate/AggregateRepositoryTest.php
+++ b/tests/Aggregate/AggregateRepositoryTest.php
@@ -399,4 +399,32 @@ class AggregateRepositoryTest extends TestCase
 
         $this->eventStore->commit();
     }
+
+    /**
+     * @test
+     */
+    public function it_clears_identity_map_manually() : void
+    {
+        $this->eventStore->beginTransaction();
+
+        $user = User::create('John Doe', 'contact@prooph.de');
+
+        $this->repository->addAggregateRoot($user);
+
+        $this->eventStore->commit();
+
+        // fill identity map
+        $fetchedUser = $this->repository->getAggregateRoot(
+            $user->getId()->toString()
+        );
+
+        $reflectionClass = new \ReflectionClass($this->repository);
+
+        $reflectionProperty = $reflectionClass->getProperty('identityMap');
+        $reflectionProperty->setAccessible(true);
+
+        self::assertCount(1, $reflectionProperty->getValue($this->repository));
+        $this->repository->clearIdentityMap();
+        self::assertCount(0, $reflectionProperty->getValue($this->repository));
+    }
 }


### PR DESCRIPTION
This is useful if you load thousands of aggregates for reading only, otherwise memory will be exhausted sometime