### PR TITLE
Improve projection factories, use a simple callable definition

### DIFF
--- a/src/ActionEventEmitterEventStore.php
+++ b/src/ActionEventEmitterEventStore.php
@@ -313,9 +313,7 @@ class ActionEventEmitterEventStore implements EventStore, EventStoreDecorator
             $factory = $this->getDefaultQueryFactory();
         }
 
-        $factory->setEventStore($this);
-
-        return $factory->factory();
+        return $factory($this);
     }
 
     public function createProjection(
@@ -327,9 +325,7 @@ class ActionEventEmitterEventStore implements EventStore, EventStoreDecorator
             $factory = $this->getDefaultProjectionFactory();
         }
 
-        $factory->setEventStore($this);
-
-        return $factory->factory($name, $options);
+        return $factory($this, $name, $options);
     }
 
     public function createReadModelProjection(
@@ -342,9 +338,7 @@ class ActionEventEmitterEventStore implements EventStore, EventStoreDecorator
             $factory = $this->getDefaultReadModelProjectionFactory();
         }
 
-        $factory->setEventStore($this);
-
-        return $factory->factory($name, $readModel, $options);
+        return $factory($this, $name, $readModel, $options);
     }
 
     public function getDefaultQueryFactory(): QueryFactory

--- a/src/InMemoryEventStore.php
+++ b/src/InMemoryEventStore.php
@@ -51,6 +51,27 @@ final class InMemoryEventStore implements TransactionalEventStore
      */
     private $inTransaction = false;
 
+    /**
+     * Will be lazy initialized if needed
+     *
+     * @var QueryFactory
+     */
+    private $defaultQueryFactory;
+
+    /**
+     * Will be lazy initialized if needed
+     *
+     * @var ProjectionFactory
+     */
+    private $defaultProjectionFactory;
+
+    /**
+     * Will be lazy initialized if needed
+     *
+     * @var ReadModelProjectionFactory
+     */
+    private $defaultReadModelProjectionFactory;
+
     public function create(Stream $stream): void
     {
         $streamName = $stream->streamName();
@@ -292,7 +313,7 @@ final class InMemoryEventStore implements TransactionalEventStore
             $factory = $this->getDefaultQueryFactory();
         }
 
-        return $factory->factory();
+        return $factory($this);
     }
 
     public function createProjection(
@@ -304,7 +325,7 @@ final class InMemoryEventStore implements TransactionalEventStore
             $factory = $this->getDefaultProjectionFactory();
         }
 
-        return $factory->factory($name, $options);
+        return $factory($this, $name, $options);
     }
 
     public function createReadModelProjection(
@@ -317,22 +338,34 @@ final class InMemoryEventStore implements TransactionalEventStore
             $factory = $this->getDefaultReadModelProjectionFactory();
         }
 
-        return $factory->factory($name, $readModel, $options);
+        return $factory($this, $name, $readModel, $options);
     }
 
     public function getDefaultQueryFactory(): QueryFactory
     {
-        return new InMemoryEventStoreQueryFactory($this);
+        if (null === $this->defaultQueryFactory) {
+            $this->defaultQueryFactory = new InMemoryEventStoreQueryFactory();
+        }
+
+        return $this->defaultQueryFactory;
     }
 
     public function getDefaultProjectionFactory(): ProjectionFactory
     {
-        return new InMemoryEventStoreProjectionFactory($this);
+        if (null === $this->defaultProjectionFactory) {
+            $this->defaultProjectionFactory = new InMemoryEventStoreProjectionFactory();
+        }
+
+        return $this->defaultProjectionFactory;
     }
 
     public function getDefaultReadModelProjectionFactory(): ReadModelProjectionFactory
     {
-        return new InMemoryEventStoreReadModelProjectionFactory($this);
+        if (null === $this->defaultReadModelProjectionFactory) {
+            $this->defaultReadModelProjectionFactory = new InMemoryEventStoreReadModelProjectionFactory();
+        }
+
+        return $this->defaultReadModelProjectionFactory;
     }
 
     private function matchesMetadata(MetadataMatcher $metadataMatcher, array $metadata): bool

--- a/src/Projection/InMemoryEventStoreProjectionFactory.php
+++ b/src/Projection/InMemoryEventStoreProjectionFactory.php
@@ -16,32 +16,20 @@ use Prooph\EventStore\EventStore;
 
 final class InMemoryEventStoreProjectionFactory implements ProjectionFactory
 {
-    /**
-     * @var EventStore
-     */
-    private $eventStore;
-
-    public function __construct(EventStore $eventStore)
-    {
-        $this->eventStore = $eventStore;
-    }
-
-    public function factory(string $name, ProjectionOptions $options = null): Projection
-    {
+    public function __invoke(
+        EventStore $eventStore,
+        string $name,
+        ProjectionOptions $options = null
+    ): Projection {
         if (null === $options) {
             $options = new ProjectionOptions();
         }
 
         return new InMemoryEventStoreProjection(
-            $this->eventStore,
+            $eventStore,
             $name,
             $options->cacheSize(),
             $options->sleep()
         );
-    }
-
-    public function setEventStore(EventStore $eventStore): void
-    {
-        $this->eventStore = $eventStore;
     }
 }

--- a/src/Projection/InMemoryEventStoreQueryFactory.php
+++ b/src/Projection/InMemoryEventStoreQueryFactory.php
@@ -16,23 +16,8 @@ use Prooph\EventStore\EventStore;
 
 final class InMemoryEventStoreQueryFactory implements QueryFactory
 {
-    /**
-     * @var EventStore
-     */
-    private $eventStore;
-
-    public function __construct(EventStore $eventStore)
+    public function __invoke(EventStore $eventStore, ProjectionOptions $options = null): Query
     {
-        $this->eventStore = $eventStore;
-    }
-
-    public function factory(ProjectionOptions $options = null): Query
-    {
-        return new InMemoryEventStoreQuery($this->eventStore);
-    }
-
-    public function setEventStore(EventStore $eventStore): void
-    {
-        $this->eventStore = $eventStore;
+        return new InMemoryEventStoreQuery($eventStore);
     }
 }

--- a/src/Projection/InMemoryEventStoreReadModelProjectionFactory.php
+++ b/src/Projection/InMemoryEventStoreReadModelProjectionFactory.php
@@ -16,34 +16,23 @@ use Prooph\EventStore\EventStore;
 
 final class InMemoryEventStoreReadModelProjectionFactory implements ReadModelProjectionFactory
 {
-    /**
-     * @var EventStore
-     */
-    private $eventStore;
-
-    public function __construct(EventStore $eventStore)
-    {
-        $this->eventStore = $eventStore;
-    }
-
-    public function factory(string $name, ReadModel $readModel, ProjectionOptions $options = null): ReadModelProjection
-    {
+    public function __invoke(
+        EventStore $eventStore,
+        string $name,
+        ReadModel $readModel,
+        ProjectionOptions $options = null
+    ): ReadModelProjection {
         if (null === $options) {
             $options = new ProjectionOptions();
         }
 
         return new InMemoryEventStoreReadModelProjection(
-            $this->eventStore,
+            $eventStore,
             $name,
             $readModel,
             $options->cacheSize(),
             $options->persistBlockSize(),
             $options->sleep()
         );
-    }
-
-    public function setEventStore(EventStore $eventStore): void
-    {
-        $this->eventStore = $eventStore;
     }
 }

--- a/src/Projection/ProjectionFactory.php
+++ b/src/Projection/ProjectionFactory.php
@@ -16,7 +16,9 @@ use Prooph\EventStore\EventStore;
 
 interface ProjectionFactory
 {
-    public function factory(string $name, ProjectionOptions $options = null): Projection;
-
-    public function setEventStore(EventStore $eventStore): void;
+    public function __invoke(
+        EventStore $eventStore,
+        string $name,
+        ProjectionOptions $options = null
+    ): Projection;
 }

--- a/src/Projection/QueryFactory.php
+++ b/src/Projection/QueryFactory.php
@@ -16,7 +16,5 @@ use Prooph\EventStore\EventStore;
 
 interface QueryFactory
 {
-    public function factory(ProjectionOptions $options = null): Query;
-
-    public function setEventStore(EventStore $eventStore): void;
+    public function __invoke(EventStore $eventStore, ProjectionOptions $options = null): Query;
 }

--- a/src/Projection/ReadModelProjectionFactory.php
+++ b/src/Projection/ReadModelProjectionFactory.php
@@ -16,7 +16,10 @@ use Prooph\EventStore\EventStore;
 
 interface ReadModelProjectionFactory
 {
-    public function factory(string $name, ReadModel $readModel, ProjectionOptions $options = null): ReadModelProjection;
-
-    public function setEventStore(EventStore $eventStore): void;
+    public function __invoke(
+        EventStore $eventStore,
+        string $name,
+        ReadModel $readModel,
+        ProjectionOptions $options = null
+    ): ReadModelProjection;
 }

--- a/tests/Projection/InMemoryEventStoreProjectionTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectionTest.php
@@ -18,6 +18,7 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Exception\InvalidArgumentException;
 use Prooph\EventStore\Exception\RuntimeException;
 use Prooph\EventStore\Exception\StreamNotFound;
+use Prooph\EventStore\Projection\InMemoryEventStoreProjection;
 use Prooph\EventStore\Projection\ProjectionOptions;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
@@ -561,10 +562,7 @@ class InMemoryEventStoreProjectionTest extends EventStoreTestCase
 
         $eventStore = $this->prophesize(EventStore::class);
 
-        $factory = $this->eventStore->getDefaultProjectionFactory();
-        $factory->setEventStore($eventStore->reveal());
-
-        $this->eventStore->createProjection('test_projection', null, $factory);
+        new InMemoryEventStoreProjection($eventStore->reveal(), 'test_projection', 10, 10, 2000);
     }
 
     private function prepareEventStream(string $name): void

--- a/tests/Projection/InMemoryEventStoreQueryTest.php
+++ b/tests/Projection/InMemoryEventStoreQueryTest.php
@@ -17,6 +17,7 @@ use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Exception\InvalidArgumentException;
 use Prooph\EventStore\Exception\RuntimeException;
+use Prooph\EventStore\Projection\InMemoryEventStoreQuery;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\EventStoreTestCase;
@@ -414,10 +415,7 @@ class InMemoryEventStoreQueryTest extends EventStoreTestCase
 
         $eventStore = $this->prophesize(EventStore::class);
 
-        $factory = $this->eventStore->getDefaultQueryFactory();
-        $factory->setEventStore($eventStore->reveal());
-
-        $this->eventStore->createQuery($factory);
+        new InMemoryEventStoreQuery($eventStore->reveal());
     }
 
     private function prepareEventStream(string $name): void

--- a/tests/Projection/InMemoryEventStoreReadModelProjectionTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectionTest.php
@@ -623,10 +623,7 @@ class InMemoryEventStoreReadModelProjectionTest extends EventStoreTestCase
 
         $eventStore = $this->prophesize(EventStore::class);
 
-        $factory = $this->eventStore->getDefaultReadModelProjectionFactory();
-        $factory->setEventStore($eventStore->reveal());
-
-        $this->eventStore->createReadModelProjection('test_projection', new ReadModelMock(), null, $factory);
+        new InMemoryEventStoreReadModelProjection($eventStore->reveal(), 'test_projection', new ReadModelMock(), 10, 10, 2000);
     }
 
     private function prepareEventStream(string $name): void


### PR DESCRIPTION
I've updated the Exception tests, because with this implementation, no wrong EventStore can be injected. Since the factories are callables, the event store is provided to the factory by the function itself.

Added lazy intializing of default factories. This has a better performance, instead of creating the factory by each call. The Factory is also stateless now. 