### PR TITLE
Add testCase to handle stream only with new events

### DIFF
--- a/src/Exception/NoNewerEventsFound.php
+++ b/src/Exception/NoNewerEventsFound.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the prooph/event-store.
+ * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Exception;
+
+use Prooph\EventStore\StreamName;
+
+final class NoNewerEventsFound extends RuntimeException
+{
+    public static function with(StreamName $streamName): NoNewerEventsFound
+    {
+        return new self(
+            sprintf(
+                'No newer events found in stream with name %s',
+                $streamName->toString()
+            )
+        );
+    }
+}

--- a/src/InMemoryEventStore.php
+++ b/src/InMemoryEventStore.php
@@ -15,6 +15,7 @@ namespace Prooph\EventStore;
 use ArrayIterator;
 use Iterator;
 use Prooph\Common\Messaging\Message;
+use Prooph\EventStore\Exception\NoNewerEventsFound;
 use Prooph\EventStore\Exception\StreamExistsAlready;
 use Prooph\EventStore\Exception\StreamNotFound;
 use Prooph\EventStore\Exception\TransactionAlreadyStarted;
@@ -149,6 +150,10 @@ final class InMemoryEventStore implements TransactionalEventStore
             ) {
                 $streamEvents[] = $streamEvent;
             }
+        }
+
+        if (count($streamEvents) == 0) {
+            throw NoNewerEventsFound::with($streamName);
         }
 
         return new ArrayIterator($streamEvents);

--- a/src/Projection/InMemoryEventStoreProjection.php
+++ b/src/Projection/InMemoryEventStoreProjection.php
@@ -328,8 +328,7 @@ final class InMemoryEventStoreProjection implements Projection
             foreach ($this->streamPositions as $streamName => $position) {
                 try {
                     $streamEvents = $this->eventStore->load(new StreamName($streamName), $position + 1);
-                } catch (Exception\StreamNotFound $e) {
-                    // no newer events found
+                } catch (Exception\NoNewerEventsFound $e) {
                     continue;
                 }
 


### PR DESCRIPTION
I added a testcase to increase the linecoverage in the eventStoreProjection.
If there are no new events, a NoNewerEventsFound-Exeption will be thrown and catched.
So the loop continues checking the next stream.
Please note, there is a possible case, that the projection cannot be stopped.
