### PR TITLE
Update test it_resumes_projection_from_position

### DIFF
--- a/src/Projection/InMemoryEventStoreProjection.php
+++ b/src/Projection/InMemoryEventStoreProjection.php
@@ -326,12 +326,7 @@ final class InMemoryEventStoreProjection implements Projection
             $eventCounter = 0;
 
             foreach ($this->streamPositions as $streamName => $position) {
-                try {
-                    $streamEvents = $this->eventStore->load(new StreamName($streamName), $position + 1);
-                } catch (Exception\StreamNotFound $e) {
-                    // no newer events found
-                    continue;
-                }
+                $streamEvents = $this->eventStore->load(new StreamName($streamName), $position + 1);
 
                 if ($singleHandler) {
                     $this->handleStreamWithSingleHandler($streamName, $streamEvents);

--- a/src/Projection/InMemoryEventStoreReadModelProjection.php
+++ b/src/Projection/InMemoryEventStoreReadModelProjection.php
@@ -293,12 +293,7 @@ final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
             $eventCounter = 0;
 
             foreach ($this->streamPositions as $streamName => $position) {
-                try {
-                    $streamEvents = $this->eventStore->load(new StreamName($streamName), $position + 1);
-                } catch (Exception\StreamNotFound $e) {
-                    // no newer events found
-                    continue;
-                }
+                $streamEvents = $this->eventStore->load(new StreamName($streamName), $position + 1);
 
                 if ($singleHandler) {
                     $this->handleStreamWithSingleHandler($streamName, $streamEvents);

--- a/tests/Projection/InMemoryEventStoreProjectionTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectionTest.php
@@ -208,6 +208,9 @@ class InMemoryEventStoreProjectionTest extends EventStoreTestCase
         $this->assertEquals(4, $projection->getState()['count']);
     }
 
+    /**
+     * @test
+     */
     public function it_resumes_projection_from_position(): void
     {
         $this->prepareEventStream('user-123');
@@ -239,7 +242,7 @@ class InMemoryEventStoreProjectionTest extends EventStoreTestCase
 
         $this->eventStore->appendTo(new StreamName('user-123'), new ArrayIterator($events));
 
-        $projection->run();
+        $projection->run(false);
 
         $this->assertEquals(99, $projection->getState()['count']);
     }


### PR DESCRIPTION
In this test the annotation is missing.
The projection has to run with the keepRunning-param = false.