### PR TITLE
improves fetchProjectionNames method

### DIFF
--- a/src/Exception/OutOfRangeException.php
+++ b/src/Exception/OutOfRangeException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the prooph/event-store.
+ * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Exception;
+
+class OutOfRangeException extends InvalidArgumentException implements EventStoreException
+{
+}

--- a/src/Projection/InMemoryProjectionManager.php
+++ b/src/Projection/InMemoryProjectionManager.php
@@ -114,7 +114,7 @@ final class InMemoryProjectionManager implements ProjectionManager
 
     public function fetchProjectionNames(?string $filter, int $limit = 20, int $offset = 0): array
     {
-        if (0 >= $limit) {
+        if (1 > $limit) {
             throw new Exception\OutOfRangeException(
                 'Invalid limit "'.$limit.'" given. Must be greater than 0.'
             );
@@ -128,10 +128,9 @@ final class InMemoryProjectionManager implements ProjectionManager
 
         if (null === $filter) {
             $result = array_keys($this->projections);
-            $result = array_slice($result, $offset, $limit);
-            sort($result, \SORT_NATURAL);
+            sort($result, \SORT_STRING);
 
-            return $result;
+            return array_slice($result, $offset, $limit);
         }
 
         if (isset($this->projections[$filter])) {
@@ -143,7 +142,7 @@ final class InMemoryProjectionManager implements ProjectionManager
 
     public function fetchProjectionNamesRegex(string $regex, int $limit = 20, int $offset = 0): array
     {
-        if (0 >= $limit) {
+        if (1 > $limit) {
             throw new Exception\OutOfRangeException(
                 'Invalid limit "'.$limit.'" given. Must be greater than 0.'
             );
@@ -161,7 +160,7 @@ final class InMemoryProjectionManager implements ProjectionManager
 
         try {
             $result = preg_grep("/$regex/", array_keys($this->projections));
-            sort($result, \SORT_NATURAL);
+            sort($result, \SORT_STRING);
 
             return array_slice($result, $offset, $limit);
         } catch (Exception\RuntimeException $e) {

--- a/src/Projection/ProjectionManager.php
+++ b/src/Projection/ProjectionManager.php
@@ -36,7 +36,12 @@ interface ProjectionManager
     /**
      * @return string[]
      */
-    public function fetchProjectionNames(?string $filter, bool $regex, int $limit, int $offset): array;
+    public function fetchProjectionNames(?string $filter, int $limit = 20, int $offset = 0): array;
+
+    /**
+     * @return string[]
+     */
+    public function fetchProjectionNamesRegex(string $regex, int $limit = 20, int $offset = 0): array;
 
     public function fetchProjectionStatus(string $name): ProjectionStatus;
 

--- a/tests/Projection/InMemoryProjectionManagerTest.php
+++ b/tests/Projection/InMemoryProjectionManagerTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception\InvalidArgumentException;
+use Prooph\EventStore\Exception\OutOfRangeException;
 use Prooph\EventStore\Exception\RuntimeException;
 use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
@@ -102,29 +103,115 @@ class InMemoryProjectionManagerTest extends TestCase
             $this->projectionManager->createProjection(uniqid('rand'));
         }
 
-        $this->assertCount(70, $this->projectionManager->fetchProjectionNames(null, false, 200, 0));
-        $this->assertCount(0, $this->projectionManager->fetchProjectionNames(null, false, 200, 100));
-        $this->assertCount(10, $this->projectionManager->fetchProjectionNames(null, false, 10, 0));
-        $this->assertCount(10, $this->projectionManager->fetchProjectionNames(null, false, 10, 10));
-        $this->assertCount(5, $this->projectionManager->fetchProjectionNames(null, false, 10, 65));
+        $this->assertCount(20, $this->projectionManager->fetchProjectionNames(null));
+        $this->assertCount(70, $this->projectionManager->fetchProjectionNames(null, 200));
+        $this->assertCount(70, $this->projectionManager->fetchProjectionNames(null, 200, 0));
+        $this->assertCount(0, $this->projectionManager->fetchProjectionNames(null, 200, 100));
+        $this->assertCount(10, $this->projectionManager->fetchProjectionNames(null, 10, 0));
+        $this->assertCount(10, $this->projectionManager->fetchProjectionNames(null, 10, 10));
+        $this->assertCount(5, $this->projectionManager->fetchProjectionNames(null, 10, 65));
 
         for ($i = 50; $i < 70; $i++) {
-            $this->assertStringStartsWith('rand', $this->projectionManager->fetchProjectionNames(null, false, 1, $i)[0]);
+            $this->assertStringStartsWith('rand', $this->projectionManager->fetchProjectionNames(null, 1, $i)[0]);
         }
-
-        $this->assertCount(30, $this->projectionManager->fetchProjectionNames('ser-', true, 30, 0));
-        $this->assertCount(0, $this->projectionManager->fetchProjectionNames('n-', true, 30, 0));
     }
 
     /**
      * @test
      */
-    public function it_throws_exception_when_fetching_projection_names_using_regex_and_no_filter(): void
+    public function it_fetches_projection_names_in_natural_order(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No regex pattern given');
+        $this->projectionManager->createProjection('user-100');
+        $this->projectionManager->createProjection('user-21');
+        $this->projectionManager->createProjection('rand-5');
+        $this->projectionManager->createProjection('user-10');
+        $this->projectionManager->createProjection('user-1');
 
-        $this->projectionManager->fetchProjectionNames(null, true, 10, 0);
+        $this->assertEquals(
+            json_encode(['rand-5', 'user-1', 'user-10', 'user-21', 'user-100']),
+            json_encode($this->projectionManager->fetchProjectionNames(null))
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_fetching_projection_names_using_invalid_limit(): void
+    {
+        $this->expectException(OutOfRangeException::class);
+        $this->expectExceptionMessage('Invalid limit "-1" given. Must be greater than 0.');
+
+        $this->projectionManager->fetchProjectionNames(null, -1, 0);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_fetching_projection_names_using_invalid_offset(): void
+    {
+        $this->expectException(OutOfRangeException::class);
+        $this->expectExceptionMessage('Invalid offset "-1" given. Must be greater or equal than 0.');
+
+        $this->projectionManager->fetchProjectionNames(null, 1, -1);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fetches_projection_names_using_regex(): void
+    {
+        for ($i = 0; $i < 50; $i++) {
+            $this->projectionManager->createProjection('user-' . $i);
+        }
+
+        for ($i = 0; $i < 20; $i++) {
+            $this->projectionManager->createProjection(uniqid('rand'));
+        }
+
+        $this->assertCount(20, $this->projectionManager->fetchProjectionNamesRegex('user'));
+        $this->assertCount(50, $this->projectionManager->fetchProjectionNamesRegex('user', 100));
+        $this->assertCount(30, $this->projectionManager->fetchProjectionNamesRegex('ser-', 30, 0));
+        $this->assertCount(0, $this->projectionManager->fetchProjectionNamesRegex('n-', 30, 0));
+        $this->assertCount(5, $this->projectionManager->fetchProjectionNamesRegex('rand', 100, 15));
+    }
+
+    /**
+     * @test
+     */
+    public function it_fetches_projection_names_in_natural_order_using_regex(): void
+    {
+        $this->projectionManager->createProjection('user-100');
+        $this->projectionManager->createProjection('user-21');
+        $this->projectionManager->createProjection('rand-5');
+        $this->projectionManager->createProjection('user-10');
+        $this->projectionManager->createProjection('user-1');
+
+        $this->assertEquals(
+            json_encode(['user-1', 'user-10', 'user-21', 'user-100']),
+            json_encode($this->projectionManager->fetchProjectionNamesRegex('ser-'))
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_fetching_projection_names_using_regex_with_invalid_limit(): void
+    {
+        $this->expectException(OutOfRangeException::class);
+        $this->expectExceptionMessage('Invalid limit "-1" given. Must be greater than 0.');
+
+        $this->projectionManager->fetchProjectionNamesRegex('foo', -1, 0);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_fetching_projection_names_using_regex_with_invalid_offset(): void
+    {
+        $this->expectException(OutOfRangeException::class);
+        $this->expectExceptionMessage('Invalid offset "-1" given. Must be greater or equal than 0.');
+
+        $this->projectionManager->fetchProjectionNamesRegex('bar', 1, -1);
     }
 
     /**
@@ -135,7 +222,7 @@ class InMemoryProjectionManagerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid regex pattern given');
 
-        $this->projectionManager->fetchProjectionNames('invalid)', true, 10, 0);
+        $this->projectionManager->fetchProjectionNamesRegex('invalid)', 10, 0);
     }
 
     /**

--- a/tests/Projection/InMemoryProjectionManagerTest.php
+++ b/tests/Projection/InMemoryProjectionManagerTest.php
@@ -111,7 +111,7 @@ class InMemoryProjectionManagerTest extends TestCase
         $this->assertCount(10, $this->projectionManager->fetchProjectionNames(null, 10, 10));
         $this->assertCount(5, $this->projectionManager->fetchProjectionNames(null, 10, 65));
 
-        for ($i = 50; $i < 70; $i++) {
+        for ($i = 0; $i < 20; $i++) {
             $this->assertStringStartsWith('rand', $this->projectionManager->fetchProjectionNames(null, 1, $i)[0]);
         }
     }
@@ -119,7 +119,26 @@ class InMemoryProjectionManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_fetches_projection_names_in_natural_order(): void
+    public function it_fetches_projection_names_with_filter(): void
+    {
+        $this->projectionManager->createProjection('user-1');
+        $this->projectionManager->createProjection('user-2');
+        $this->projectionManager->createProjection('rand-1');
+        $this->projectionManager->createProjection('user-3');
+
+        $this->assertSame(['user-1'], $this->projectionManager->fetchProjectionNames('user-1'));
+        $this->assertSame(['user-2'], $this->projectionManager->fetchProjectionNames('user-2', 2));
+        $this->assertSame(['rand-1'], $this->projectionManager->fetchProjectionNames('rand-1', 5, 100));
+
+        $this->assertSame([], $this->projectionManager->fetchProjectionNames('foo'));
+        $this->assertSame([], $this->projectionManager->fetchProjectionNames('foo', 5));
+        $this->assertSame([], $this->projectionManager->fetchProjectionNames('foo', 10, 100));
+    }
+
+    /**
+     * @test
+     */
+    public function it_fetches_projection_names_sorted(): void
     {
         $this->projectionManager->createProjection('user-100');
         $this->projectionManager->createProjection('user-21');
@@ -128,7 +147,7 @@ class InMemoryProjectionManagerTest extends TestCase
         $this->projectionManager->createProjection('user-1');
 
         $this->assertEquals(
-            json_encode(['rand-5', 'user-1', 'user-10', 'user-21', 'user-100']),
+            json_encode(['rand-5', 'user-1', 'user-10', 'user-100', 'user-21']),
             json_encode($this->projectionManager->fetchProjectionNames(null))
         );
     }
@@ -178,7 +197,7 @@ class InMemoryProjectionManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_fetches_projection_names_in_natural_order_using_regex(): void
+    public function it_fetches_projection_names_sorted_using_regex(): void
     {
         $this->projectionManager->createProjection('user-100');
         $this->projectionManager->createProjection('user-21');
@@ -187,7 +206,7 @@ class InMemoryProjectionManagerTest extends TestCase
         $this->projectionManager->createProjection('user-1');
 
         $this->assertEquals(
-            json_encode(['user-1', 'user-10', 'user-21', 'user-100']),
+            json_encode(['user-1', 'user-10', 'user-100', 'user-21']),
             json_encode($this->projectionManager->fetchProjectionNamesRegex('ser-'))
         );
     }


### PR DESCRIPTION
Hi @prolic !

This PR
- removes regex test with error suppression
- moves the regex test to a separate method (maybe for later usage, move it back if not wanted)
- removes the ksort on an indexed array .. makes no sense here ;)
- removes the overloaded foreach loop. My approach should return the same result.
- removes else \o/
