### PR TITLE
rename projection => projector where applicable

### DIFF
--- a/src/Projection/InMemoryEventStoreProjector.php
+++ b/src/Projection/InMemoryEventStoreProjector.php
@@ -24,7 +24,7 @@ use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use Prooph\EventStore\Util\ArrayCache;
 
-final class InMemoryEventStoreProjection implements Projection
+final class InMemoryEventStoreProjector implements Projector
 {
     /**
      * @var string
@@ -128,10 +128,10 @@ final class InMemoryEventStoreProjection implements Projection
         $this->innerEventStore = $eventStore;
     }
 
-    public function init(Closure $callback): Projection
+    public function init(Closure $callback): Projector
     {
         if (null !== $this->initCallback) {
-            throw new Exception\RuntimeException('Projection already initialized');
+            throw new Exception\RuntimeException('Projector already initialized');
         }
 
         $callback = Closure::bind($callback, $this->createHandlerContext($this->currentStreamName));
@@ -147,7 +147,7 @@ final class InMemoryEventStoreProjection implements Projection
         return $this;
     }
 
-    public function fromStream(string $streamName): Projection
+    public function fromStream(string $streamName): Projector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
@@ -158,7 +158,7 @@ final class InMemoryEventStoreProjection implements Projection
         return $this;
     }
 
-    public function fromStreams(string ...$streamNames): Projection
+    public function fromStreams(string ...$streamNames): Projector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
@@ -171,7 +171,7 @@ final class InMemoryEventStoreProjection implements Projection
         return $this;
     }
 
-    public function fromCategory(string $name): Projection
+    public function fromCategory(string $name): Projector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
@@ -182,7 +182,7 @@ final class InMemoryEventStoreProjection implements Projection
         return $this;
     }
 
-    public function fromCategories(string ...$names): Projection
+    public function fromCategories(string ...$names): Projector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
@@ -195,7 +195,7 @@ final class InMemoryEventStoreProjection implements Projection
         return $this;
     }
 
-    public function fromAll(): Projection
+    public function fromAll(): Projector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
@@ -206,7 +206,7 @@ final class InMemoryEventStoreProjection implements Projection
         return $this;
     }
 
-    public function when(array $handlers): Projection
+    public function when(array $handlers): Projector
     {
         if (null !== $this->handler || ! empty($this->handlers)) {
             throw new Exception\RuntimeException('When was already called');
@@ -227,7 +227,7 @@ final class InMemoryEventStoreProjection implements Projection
         return $this;
     }
 
-    public function whenAny(Closure $handler): Projection
+    public function whenAny(Closure $handler): Projector
     {
         if (null !== $this->handler || ! empty($this->handlers)) {
             throw new Exception\RuntimeException('When was already called');
@@ -413,7 +413,7 @@ final class InMemoryEventStoreProjection implements Projection
     {
         return new class($this, $streamName) {
             /**
-             * @var Projection
+             * @var Projector
              */
             private $projection;
 
@@ -422,7 +422,7 @@ final class InMemoryEventStoreProjection implements Projection
              */
             private $streamName;
 
-            public function __construct(Projection $projection, ?string &$streamName)
+            public function __construct(Projector $projection, ?string &$streamName)
             {
                 $this->projection = $projection;
                 $this->streamName = &$streamName;

--- a/src/Projection/InMemoryEventStoreProjector.php
+++ b/src/Projection/InMemoryEventStoreProjector.php
@@ -415,32 +415,32 @@ final class InMemoryEventStoreProjector implements Projector
             /**
              * @var Projector
              */
-            private $projection;
+            private $projector;
 
             /**
              * @var ?string
              */
             private $streamName;
 
-            public function __construct(Projector $projection, ?string &$streamName)
+            public function __construct(Projector $projector, ?string &$streamName)
             {
-                $this->projection = $projection;
+                $this->projector = $projector;
                 $this->streamName = &$streamName;
             }
 
             public function stop(): void
             {
-                $this->projection->stop();
+                $this->projector->stop();
             }
 
             public function linkTo(string $streamName, Message $event): void
             {
-                $this->projection->linkTo($streamName, $event);
+                $this->projector->linkTo($streamName, $event);
             }
 
             public function emit(Message $event): void
             {
-                $this->projection->emit($event);
+                $this->projector->emit($event);
             }
 
             public function streamName(): ?string

--- a/src/Projection/InMemoryEventStoreProjector.php
+++ b/src/Projection/InMemoryEventStoreProjector.php
@@ -131,7 +131,7 @@ final class InMemoryEventStoreProjector implements Projector
     public function init(Closure $callback): Projector
     {
         if (null !== $this->initCallback) {
-            throw new Exception\RuntimeException('Projector already initialized');
+            throw new Exception\RuntimeException('Projection already initialized');
         }
 
         $callback = Closure::bind($callback, $this->createHandlerContext($this->currentStreamName));

--- a/src/Projection/InMemoryEventStoreQuery.php
+++ b/src/Projection/InMemoryEventStoreQuery.php
@@ -91,7 +91,7 @@ final class InMemoryEventStoreQuery implements Query
     public function init(Closure $callback): Query
     {
         if (null !== $this->initCallback) {
-            throw new Exception\RuntimeException('Projection already initialized');
+            throw new Exception\RuntimeException('Query is already initialized');
         }
 
         $callback = Closure::bind($callback, $this->createHandlerContext($this->currentStreamName));

--- a/src/Projection/InMemoryEventStoreQuery.php
+++ b/src/Projection/InMemoryEventStoreQuery.php
@@ -91,7 +91,7 @@ final class InMemoryEventStoreQuery implements Query
     public function init(Closure $callback): Query
     {
         if (null !== $this->initCallback) {
-            throw new Exception\RuntimeException('Projection already initialized');
+            throw new Exception\RuntimeException('Projector already initialized');
         }
 
         $callback = Closure::bind($callback, $this->createHandlerContext($this->currentStreamName));

--- a/src/Projection/InMemoryEventStoreQuery.php
+++ b/src/Projection/InMemoryEventStoreQuery.php
@@ -91,7 +91,7 @@ final class InMemoryEventStoreQuery implements Query
     public function init(Closure $callback): Query
     {
         if (null !== $this->initCallback) {
-            throw new Exception\RuntimeException('Projector already initialized');
+            throw new Exception\RuntimeException('Projection already initialized');
         }
 
         $callback = Closure::bind($callback, $this->createHandlerContext($this->currentStreamName));

--- a/src/Projection/InMemoryEventStoreReadModelProjector.php
+++ b/src/Projection/InMemoryEventStoreReadModelProjector.php
@@ -151,7 +151,7 @@ final class InMemoryEventStoreReadModelProjector implements ReadModelProjector
     public function init(Closure $callback): ReadModelProjector
     {
         if (null !== $this->initCallback) {
-            throw new Exception\RuntimeException('Projector already initialized');
+            throw new Exception\RuntimeException('Projection already initialized');
         }
 
         $callback = Closure::bind($callback, $this->createHandlerContext($this->currentStreamName));

--- a/src/Projection/InMemoryEventStoreReadModelProjector.php
+++ b/src/Projection/InMemoryEventStoreReadModelProjector.php
@@ -22,7 +22,7 @@ use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\StreamName;
 use Prooph\EventStore\Util\ArrayCache;
 
-final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
+final class InMemoryEventStoreReadModelProjector implements ReadModelProjector
 {
     /**
      * @var string
@@ -148,10 +148,10 @@ final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
         $this->innerEventStore = $eventStore;
     }
 
-    public function init(Closure $callback): ReadModelProjection
+    public function init(Closure $callback): ReadModelProjector
     {
         if (null !== $this->initCallback) {
-            throw new Exception\RuntimeException('Projection already initialized');
+            throw new Exception\RuntimeException('Projector already initialized');
         }
 
         $callback = Closure::bind($callback, $this->createHandlerContext($this->currentStreamName));
@@ -167,7 +167,7 @@ final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
         return $this;
     }
 
-    public function fromStream(string $streamName): ReadModelProjection
+    public function fromStream(string $streamName): ReadModelProjector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
@@ -178,7 +178,7 @@ final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
         return $this;
     }
 
-    public function fromStreams(string ...$streamNames): ReadModelProjection
+    public function fromStreams(string ...$streamNames): ReadModelProjector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
@@ -191,7 +191,7 @@ final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
         return $this;
     }
 
-    public function fromCategory(string $name): ReadModelProjection
+    public function fromCategory(string $name): ReadModelProjector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
@@ -202,7 +202,7 @@ final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
         return $this;
     }
 
-    public function fromCategories(string ...$names): ReadModelProjection
+    public function fromCategories(string ...$names): ReadModelProjector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
@@ -215,7 +215,7 @@ final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
         return $this;
     }
 
-    public function fromAll(): ReadModelProjection
+    public function fromAll(): ReadModelProjector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
@@ -226,7 +226,7 @@ final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
         return $this;
     }
 
-    public function when(array $handlers): ReadModelProjection
+    public function when(array $handlers): ReadModelProjector
     {
         if (null !== $this->handler || ! empty($this->handlers)) {
             throw new Exception\RuntimeException('When was already called');
@@ -247,7 +247,7 @@ final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
         return $this;
     }
 
-    public function whenAny(Closure $handler): ReadModelProjection
+    public function whenAny(Closure $handler): ReadModelProjector
     {
         if (null !== $this->handler || ! empty($this->handlers)) {
             throw new Exception\RuntimeException('When was already called');
@@ -419,7 +419,7 @@ final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
     {
         return new class($this, $streamName) {
             /**
-             * @var ReadModelProjection
+             * @var ReadModelProjector
              */
             private $projection;
 
@@ -428,7 +428,7 @@ final class InMemoryEventStoreReadModelProjection implements ReadModelProjection
              */
             private $streamName;
 
-            public function __construct(ReadModelProjection $projection, ?string &$streamName)
+            public function __construct(ReadModelProjector $projection, ?string &$streamName)
             {
                 $this->projection = $projection;
                 $this->streamName = &$streamName;

--- a/src/Projection/InMemoryEventStoreReadModelProjector.php
+++ b/src/Projection/InMemoryEventStoreReadModelProjector.php
@@ -151,7 +151,7 @@ final class InMemoryEventStoreReadModelProjector implements ReadModelProjector
     public function init(Closure $callback): ReadModelProjector
     {
         if (null !== $this->initCallback) {
-            throw new Exception\RuntimeException('Projection already initialized');
+            throw new Exception\RuntimeException('Projector is already initialized');
         }
 
         $callback = Closure::bind($callback, $this->createHandlerContext($this->currentStreamName));
@@ -421,27 +421,27 @@ final class InMemoryEventStoreReadModelProjector implements ReadModelProjector
             /**
              * @var ReadModelProjector
              */
-            private $projection;
+            private $projector;
 
             /**
              * @var ?string
              */
             private $streamName;
 
-            public function __construct(ReadModelProjector $projection, ?string &$streamName)
+            public function __construct(ReadModelProjector $projector, ?string &$streamName)
             {
-                $this->projection = $projection;
+                $this->projector = $projector;
                 $this->streamName = &$streamName;
             }
 
             public function stop(): void
             {
-                $this->projection->stop();
+                $this->projector->stop();
             }
 
             public function readModel(): ReadModel
             {
-                return $this->projection->readModel();
+                return $this->projector->readModel();
             }
 
             public function streamName(): ?string

--- a/src/Projection/InMemoryProjectionManager.php
+++ b/src/Projection/InMemoryProjectionManager.php
@@ -168,12 +168,12 @@ final class InMemoryProjectionManager implements ProjectionManager
             throw new Exception\RuntimeException('A projection with name "' . $name . '" could not be found.');
         }
 
-        $projection = $this->projectors[$name];
+        $projector = $this->projectors[$name];
 
-        $ref = new \ReflectionProperty(get_class($projection), 'status');
+        $ref = new \ReflectionProperty(get_class($projector), 'status');
         $ref->setAccessible(true);
 
-        return $ref->getValue($projection);
+        return $ref->getValue($projector);
     }
 
     public function fetchProjectionStreamPositions(string $name): array
@@ -182,11 +182,11 @@ final class InMemoryProjectionManager implements ProjectionManager
             throw new Exception\RuntimeException('A projection with name "' . $name . '" could not be found.');
         }
 
-        $projection = $this->projectors[$name];
+        $projector = $this->projectors[$name];
 
-        $ref = new \ReflectionProperty(get_class($projection), 'streamPositions');
+        $ref = new \ReflectionProperty(get_class($projector), 'streamPositions');
         $ref->setAccessible(true);
-        $value = $ref->getValue($projection);
+        $value = $ref->getValue($projector);
 
         return (null === $value) ? [] : $value;
     }

--- a/src/Projection/InMemoryProjectionManager.php
+++ b/src/Projection/InMemoryProjectionManager.php
@@ -53,12 +53,12 @@ final class InMemoryProjectionManager implements ProjectionManager
     public function createProjection(
         string $name,
         array $options = null
-    ): Projection {
-        $projection = new InMemoryEventStoreProjection(
+    ): Projector {
+        $projection = new InMemoryEventStoreProjector(
             $this->eventStore,
             $name,
-            $options[self::OPTION_CACHE_SIZE] ?? self::DEFAULT_CACHE_SIZE,
-            $options[self::OPTION_SLEEP] ?? self::DEFAULT_SLEEP
+            $options[Projector::OPTION_CACHE_SIZE] ?? Projector::DEFAULT_CACHE_SIZE,
+            $options[Projector::OPTION_SLEEP] ?? Projector::DEFAULT_SLEEP
         );
 
         if (! isset($this->projections[$name])) {
@@ -72,14 +72,14 @@ final class InMemoryProjectionManager implements ProjectionManager
         string $name,
         ReadModel $readModel,
         array $options = null
-    ): ReadModelProjection {
-        $projection = new InMemoryEventStoreReadModelProjection(
+    ): ReadModelProjector {
+        $projection = new InMemoryEventStoreReadModelProjector(
             $this->eventStore,
             $name,
             $readModel,
-            $options[self::OPTION_CACHE_SIZE] ?? self::DEFAULT_CACHE_SIZE,
-            $options[self::OPTION_PERSIST_BLOCK_SIZE] ?? self::DEFAULT_PERSIST_BLOCK_SIZE,
-            $options[self::OPTION_SLEEP] ?? self::DEFAULT_SLEEP
+            $options[ReadModelProjector::OPTION_CACHE_SIZE] ?? ReadModelProjector::DEFAULT_CACHE_SIZE,
+            $options[ReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? ReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
+            $options[ReadModelProjector::OPTION_SLEEP] ?? ReadModelProjector::DEFAULT_SLEEP
         );
 
         if (! isset($this->projections[$name])) {

--- a/src/Projection/ProjectionManager.php
+++ b/src/Projection/ProjectionManager.php
@@ -14,26 +14,18 @@ namespace Prooph\EventStore\Projection;
 
 interface ProjectionManager
 {
-    public const OPTION_CACHE_SIZE = 'cache_size';
-    public const OPTION_SLEEP = 'sleep';
-    public const OPTION_PERSIST_BLOCK_SIZE = 'persist_block_size';
-
-    public const DEFAULT_CACHE_SIZE = 1000;
-    public const DEFAULT_SLEEP = 100000;
-    public const DEFAULT_PERSIST_BLOCK_SIZE = 1000;
-
     public function createQuery(): Query;
 
     public function createProjection(
         string $name,
         array $options = []
-    ): Projection;
+    ): Projector;
 
     public function createReadModelProjection(
         string $name,
         ReadModel $readModel,
         array $options = []
-    ): ReadModelProjection;
+    ): ReadModelProjector;
 
     public function deleteProjection(string $name, bool $deleteEmittedEvents): void;
 

--- a/src/Projection/Projector.php
+++ b/src/Projection/Projector.php
@@ -19,9 +19,11 @@ interface Projector
 {
     public const OPTION_CACHE_SIZE = 'cache_size';
     public const OPTION_SLEEP = 'sleep';
+    public const OPTION_PERSIST_BLOCK_SIZE = 'persist_block_size';
 
     public const DEFAULT_CACHE_SIZE = 1000;
     public const DEFAULT_SLEEP = 100000;
+    public const DEFAULT_PERSIST_BLOCK_SIZE = 1000;
 
     /**
      * The callback has to return an array

--- a/src/Projection/Projector.php
+++ b/src/Projection/Projector.php
@@ -15,47 +15,53 @@ namespace Prooph\EventStore\Projection;
 use Closure;
 use Prooph\Common\Messaging\Message;
 
-interface ReadModelProjection
+interface Projector
 {
+    public const OPTION_CACHE_SIZE = 'cache_size';
+    public const OPTION_SLEEP = 'sleep';
+
+    public const DEFAULT_CACHE_SIZE = 1000;
+    public const DEFAULT_SLEEP = 100000;
+
     /**
      * The callback has to return an array
      */
-    public function init(Closure $callback): ReadModelProjection;
+    public function init(Closure $callback): Projector;
 
-    public function fromStream(string $streamName): ReadModelProjection;
+    public function fromStream(string $streamName): Projector;
 
-    public function fromStreams(string ...$streamNames): ReadModelProjection;
+    public function fromStreams(string ...$streamNames): Projector;
 
-    public function fromCategory(string $name): ReadModelProjection;
+    public function fromCategory(string $name): Projector;
 
-    public function fromCategories(string ...$names): ReadModelProjection;
+    public function fromCategories(string ...$names): Projector;
 
-    public function fromAll(): ReadModelProjection;
+    public function fromAll(): Projector;
 
     /**
      * For example:
      *
      * when([
      *     'UserCreated' => function (array $state, Message $event) {
-     *         $state->count++;
+     *         $state['count']++;
      *         return $state;
      *     },
      *     'UserDeleted' => function (array $state, Message $event) {
-     *         $state->count--;
+     *         $state['count']--;
      *         return $state;
      *     }
      * ])
      */
-    public function when(array $handlers): ReadModelProjection;
+    public function when(array $handlers): Projector;
 
     /**
      * For example:
      * function(array $state, Message $event) {
-     *     $state->count++;
+     *     $state['count']++;
      *     return $state;
      * }
      */
-    public function whenAny(Closure $closure): ReadModelProjection;
+    public function whenAny(Closure $closure): Projector;
 
     public function reset(): void;
 
@@ -65,9 +71,11 @@ interface ReadModelProjection
 
     public function getName(): string;
 
-    public function delete(bool $deleteProjection): void;
+    public function emit(Message $event): void;
+
+    public function linkTo(string $streamName, Message $event): void;
+
+    public function delete(bool $deleteEmittedEvents): void;
 
     public function run(bool $keepRunning = true): void;
-
-    public function readModel(): ReadModel;
 }

--- a/src/Projection/ReadModelProjector.php
+++ b/src/Projection/ReadModelProjector.php
@@ -13,49 +13,56 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Projection;
 
 use Closure;
-use Prooph\Common\Messaging\Message;
 
-interface Projection
+interface ReadModelProjector
 {
+    public const OPTION_CACHE_SIZE = 'cache_size';
+    public const OPTION_SLEEP = 'sleep';
+    public const OPTION_PERSIST_BLOCK_SIZE = 'persist_block_size';
+
+    public const DEFAULT_CACHE_SIZE = 1000;
+    public const DEFAULT_SLEEP = 100000;
+    public const DEFAULT_PERSIST_BLOCK_SIZE = 1000;
+
     /**
      * The callback has to return an array
      */
-    public function init(Closure $callback): Projection;
+    public function init(Closure $callback): ReadModelProjector;
 
-    public function fromStream(string $streamName): Projection;
+    public function fromStream(string $streamName): ReadModelProjector;
 
-    public function fromStreams(string ...$streamNames): Projection;
+    public function fromStreams(string ...$streamNames): ReadModelProjector;
 
-    public function fromCategory(string $name): Projection;
+    public function fromCategory(string $name): ReadModelProjector;
 
-    public function fromCategories(string ...$names): Projection;
+    public function fromCategories(string ...$names): ReadModelProjector;
 
-    public function fromAll(): Projection;
+    public function fromAll(): ReadModelProjector;
 
     /**
      * For example:
      *
      * when([
      *     'UserCreated' => function (array $state, Message $event) {
-     *         $state['count']++;
+     *         $state->count++;
      *         return $state;
      *     },
      *     'UserDeleted' => function (array $state, Message $event) {
-     *         $state['count']--;
+     *         $state->count--;
      *         return $state;
      *     }
      * ])
      */
-    public function when(array $handlers): Projection;
+    public function when(array $handlers): ReadModelProjector;
 
     /**
      * For example:
      * function(array $state, Message $event) {
-     *     $state['count']++;
+     *     $state->count++;
      *     return $state;
      * }
      */
-    public function whenAny(Closure $closure): Projection;
+    public function whenAny(Closure $closure): ReadModelProjector;
 
     public function reset(): void;
 
@@ -65,11 +72,9 @@ interface Projection
 
     public function getName(): string;
 
-    public function emit(Message $event): void;
-
-    public function linkTo(string $streamName, Message $event): void;
-
-    public function delete(bool $deleteEmittedEvents): void;
+    public function delete(bool $deleteProjection): void;
 
     public function run(bool $keepRunning = true): void;
+
+    public function readModel(): ReadModel;
 }

--- a/tests/Projection/AbstractEventStoreProjectorTest.php
+++ b/tests/Projection/AbstractEventStoreProjectorTest.php
@@ -345,7 +345,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $calledTimes = 0;
 
         $projection = $this->projectionManager->createProjection('test_projection', [
-            $this->projectionManager::OPTION_PERSIST_BLOCK_SIZE => 10,
+            Projector::OPTION_PERSIST_BLOCK_SIZE => 10,
         ]);
 
         $projection
@@ -390,7 +390,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $calledTimes = 0;
 
         $projection = $this->projectionManager->createProjection('test_projection', [
-            $this->projectionManager::OPTION_PERSIST_BLOCK_SIZE => 10,
+            Projector::OPTION_PERSIST_BLOCK_SIZE => 10,
         ]);
 
         $projection
@@ -437,7 +437,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $projectionManager = $this->projectionManager;
 
         $projection = $this->projectionManager->createProjection('test_projection', [
-            $this->projectionManager::OPTION_PERSIST_BLOCK_SIZE => 5,
+            Projector::OPTION_PERSIST_BLOCK_SIZE => 5,
         ]);
 
         $projection
@@ -479,7 +479,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $projectionManager = $this->projectionManager;
 
         $projection = $this->projectionManager->createProjection('test_projection', [
-            $this->projectionManager::OPTION_PERSIST_BLOCK_SIZE => 5,
+            Projector::OPTION_PERSIST_BLOCK_SIZE => 5,
         ]);
 
         $projection

--- a/tests/Projection/AbstractEventStoreProjectorTest.php
+++ b/tests/Projection/AbstractEventStoreProjectorTest.php
@@ -21,15 +21,16 @@ use Prooph\EventStore\Exception\RuntimeException;
 use Prooph\EventStore\Exception\StreamNotFound;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Prooph\EventStore\Projection\ProjectionStatus;
+use Prooph\EventStore\Projection\Projector;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
 
 /**
- * Common tests for all event store projection implementations
+ * Common tests for all event store projector implementations
  */
-abstract class AbstractEventStoreProjectionTest extends TestCase
+abstract class AbstractEventStoreProjectorTest extends TestCase
 {
     /**
      * @var ProjectionManager
@@ -961,9 +962,7 @@ abstract class AbstractEventStoreProjectionTest extends TestCase
     {
         $this->prepareEventStream('user-123');
 
-        $projection = $this->projectionManager->createProjection('test_projection', [
-            $this->projectionManager::OPTION_PERSIST_BLOCK_SIZE => 10,
-        ]);
+        $projection = $this->projectionManager->createProjection('test_projection');
 
         $projection
             ->init(function (): array {
@@ -987,9 +986,7 @@ abstract class AbstractEventStoreProjectionTest extends TestCase
     {
         $this->prepareEventStream('user-123');
 
-        $projection = $this->projectionManager->createProjection('test_projection', [
-            $this->projectionManager::OPTION_PERSIST_BLOCK_SIZE => 10,
-        ]);
+        $projection = $this->projectionManager->createProjection('test_projection');
 
         $projection
             ->init(function (): array {

--- a/tests/Projection/AbstractEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/AbstractEventStoreReadModelProjectorTest.php
@@ -20,6 +20,7 @@ use Prooph\EventStore\Exception\InvalidArgumentException;
 use Prooph\EventStore\Exception\RuntimeException;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Prooph\EventStore\Projection\ReadModel;
+use Prooph\EventStore\Projection\ReadModelProjector;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\ReadModelMock;
@@ -27,9 +28,9 @@ use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
 
 /**
- * Common tests for all event store read model projection implementations
+ * Common tests for all event store read model projector implementations
  */
-abstract class AbstractEventStoreReadModelProjectionTest extends TestCase
+abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
 {
     /**
      * @var ProjectionManager
@@ -639,7 +640,7 @@ abstract class AbstractEventStoreReadModelProjectionTest extends TestCase
         $readModel = new ReadModelMock();
 
         $projection = $this->projectionManager->createReadModelProjection('test_projection', $readModel, [
-            $this->projectionManager::OPTION_PERSIST_BLOCK_SIZE => 10,
+            ReadModelProjector::OPTION_PERSIST_BLOCK_SIZE => 10,
         ]);
 
         $projection
@@ -667,7 +668,7 @@ abstract class AbstractEventStoreReadModelProjectionTest extends TestCase
         $readModel = new ReadModelMock();
 
         $projection = $this->projectionManager->createReadModelProjection('test_projection', $readModel, [
-            $this->projectionManager::OPTION_PERSIST_BLOCK_SIZE => 10,
+            ReadModelProjector::OPTION_PERSIST_BLOCK_SIZE => 10,
         ]);
 
         $projection

--- a/tests/Projection/InMemoryEventStoreProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectorTest.php
@@ -16,10 +16,10 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception\InvalidArgumentException;
 use Prooph\EventStore\InMemoryEventStore;
-use Prooph\EventStore\Projection\InMemoryEventStoreProjection;
+use Prooph\EventStore\Projection\InMemoryEventStoreProjector;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
 
-class InMemoryEventStoreProjectionTest extends AbstractEventStoreProjectionTest
+class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
 {
     /**
      * @var InMemoryProjectionManager
@@ -118,7 +118,7 @@ class InMemoryEventStoreProjectionTest extends AbstractEventStoreProjectionTest
 
         $eventStore = $this->prophesize(EventStore::class);
 
-        new InMemoryEventStoreProjection($eventStore->reveal(), 'test_projection', 10, 10, 2000);
+        new InMemoryEventStoreProjector($eventStore->reveal(), 'test_projection', 10, 10, 2000);
     }
 
     /**
@@ -132,7 +132,7 @@ class InMemoryEventStoreProjectionTest extends AbstractEventStoreProjectionTest
         $wrappedEventStore = $this->prophesize(EventStoreDecorator::class);
         $wrappedEventStore->getInnerEventStore()->willReturn($eventStore->reveal())->shouldBeCalled();
 
-        new InMemoryEventStoreProjection($wrappedEventStore->reveal(), 'test_projection', 1, 1);
+        new InMemoryEventStoreProjector($wrappedEventStore->reveal(), 'test_projection', 1, 1);
     }
 
     /**
@@ -142,7 +142,7 @@ class InMemoryEventStoreProjectionTest extends AbstractEventStoreProjectionTest
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new InMemoryEventStoreProjection($this->eventStore, 'test_projection', -1, 1);
+        new InMemoryEventStoreProjector($this->eventStore, 'test_projection', -1, 1);
     }
 
     /**
@@ -152,6 +152,6 @@ class InMemoryEventStoreProjectionTest extends AbstractEventStoreProjectionTest
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new InMemoryEventStoreProjection($this->eventStore, 'test_projection', 1, -1);
+        new InMemoryEventStoreProjector($this->eventStore, 'test_projection', 1, -1);
     }
 }

--- a/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
@@ -16,11 +16,11 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception\InvalidArgumentException;
 use Prooph\EventStore\InMemoryEventStore;
-use Prooph\EventStore\Projection\InMemoryEventStoreReadModelProjection;
+use Prooph\EventStore\Projection\InMemoryEventStoreReadModelProjector;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
 use ProophTest\EventStore\Mock\ReadModelMock;
 
-class InMemoryEventStoreReadModelProjectionTest extends AbstractEventStoreReadModelProjectionTest
+class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadModelProjectorTest
 {
     /**
      * @var InMemoryProjectionManager
@@ -117,7 +117,7 @@ class InMemoryEventStoreReadModelProjectionTest extends AbstractEventStoreReadMo
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new InMemoryEventStoreReadModelProjection($this->eventStore, 'test_projection', new ReadModelMock(), -1, 1, 1);
+        new InMemoryEventStoreReadModelProjector($this->eventStore, 'test_projection', new ReadModelMock(), -1, 1, 1);
     }
 
     /**
@@ -127,7 +127,7 @@ class InMemoryEventStoreReadModelProjectionTest extends AbstractEventStoreReadMo
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new InMemoryEventStoreReadModelProjection($this->eventStore, 'test_projection', new ReadModelMock(), 1, -1, 25);
+        new InMemoryEventStoreReadModelProjector($this->eventStore, 'test_projection', new ReadModelMock(), 1, -1, 25);
     }
 
     /**
@@ -137,7 +137,7 @@ class InMemoryEventStoreReadModelProjectionTest extends AbstractEventStoreReadMo
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new InMemoryEventStoreReadModelProjection($this->eventStore, 'test_projection', new ReadModelMock(), 1, 1, -1);
+        new InMemoryEventStoreReadModelProjector($this->eventStore, 'test_projection', new ReadModelMock(), 1, 1, -1);
     }
 
     /**
@@ -149,7 +149,7 @@ class InMemoryEventStoreReadModelProjectionTest extends AbstractEventStoreReadMo
 
         $eventStore = $this->prophesize(EventStore::class);
 
-        new InMemoryEventStoreReadModelProjection($eventStore->reveal(), 'test_projection', new ReadModelMock(), 1, 1, 1);
+        new InMemoryEventStoreReadModelProjector($eventStore->reveal(), 'test_projection', new ReadModelMock(), 1, 1, 1);
     }
 
     /**
@@ -163,6 +163,6 @@ class InMemoryEventStoreReadModelProjectionTest extends AbstractEventStoreReadMo
         $wrappedEventStore = $this->prophesize(EventStoreDecorator::class);
         $wrappedEventStore->getInnerEventStore()->willReturn($eventStore->reveal())->shouldBeCalled();
 
-        new InMemoryEventStoreReadModelProjection($wrappedEventStore->reveal(), 'test_projection', new ReadModelMock(), 1, 1, 1);
+        new InMemoryEventStoreReadModelProjector($wrappedEventStore->reveal(), 'test_projection', new ReadModelMock(), 1, 1, 1);
     }
 }


### PR DESCRIPTION
move constants from projection manager to projector interfaces

resolves https://github.com/prooph/event-store/issues/273

Please check the new naming and check for consistency where it's still called projection, and where it's now called projector, f.e.

```
ProjectionManager::createProjection(): Projector
```

/cc @basz @oqq @bweston92

If accepted, we need to update pdo-event-store before merging, then we are ready for next beta I guess