### PR TITLE
updates unit tests to reflect current implementation

### DIFF
--- a/tests/AbstractEventStoreTest.php
+++ b/tests/AbstractEventStoreTest.php
@@ -197,7 +197,7 @@ abstract class AbstractEventStoreTest extends TestCase
 
         $this->eventStore->appendTo($stream->streamName(), new ArrayIterator([$streamEventVersion2, $streamEventVersion3]));
 
-        $loadedEvents = $this->eventStore->loadReverse($stream->streamName(), PHP_INT_MAX, 2);
+        $loadedEvents = $this->eventStore->loadReverse($stream->streamName(), null, 2);
 
         $this->assertCount(2, $loadedEvents);
 
@@ -207,7 +207,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $loadedEvents->next();
         $this->assertTrue($loadedEvents->current()->metadata()['snapshot']);
 
-        $streamEvents = $this->eventStore->loadReverse($stream->streamName(), PHP_INT_MAX, 2);
+        $streamEvents = $this->eventStore->loadReverse($stream->streamName(), null, 2);
 
         $this->assertCount(2, $streamEvents);
 
@@ -567,42 +567,42 @@ abstract class AbstractEventStoreTest extends TestCase
         $metadataMatcher = new MetadataMatcher();
         $metadataMatcher = $metadataMatcher->withMetadataMatch('foo', Operator::EQUALS(), 'baz');
 
-        $result = $this->eventStore->loadReverse($streamName, PHP_INT_MAX, null, $metadataMatcher);
+        $result = $this->eventStore->loadReverse($streamName, null, null, $metadataMatcher);
 
         $this->assertFalse($result->valid());
 
         $metadataMatcher = new MetadataMatcher();
         $metadataMatcher = $metadataMatcher->withMetadataMatch('foo', Operator::NOT_EQUALS(), 'bar');
 
-        $result = $this->eventStore->loadReverse($streamName, PHP_INT_MAX, null, $metadataMatcher);
+        $result = $this->eventStore->loadReverse($streamName, null, null, $metadataMatcher);
 
         $this->assertFalse($result->valid());
 
         $metadataMatcher = new MetadataMatcher();
         $metadataMatcher = $metadataMatcher->withMetadataMatch('int', Operator::GREATER_THAN(), 9);
 
-        $result = $this->eventStore->loadReverse($streamName, PHP_INT_MAX, null, $metadataMatcher);
+        $result = $this->eventStore->loadReverse($streamName, null, null, $metadataMatcher);
 
         $this->assertFalse($result->valid());
 
         $metadataMatcher = new MetadataMatcher();
         $metadataMatcher = $metadataMatcher->withMetadataMatch('int2', Operator::GREATER_THAN_EQUALS(), 10);
 
-        $result = $this->eventStore->loadReverse($streamName, PHP_INT_MAX, null, $metadataMatcher);
+        $result = $this->eventStore->loadReverse($streamName, null, null, $metadataMatcher);
 
         $this->assertFalse($result->valid());
 
         $metadataMatcher = new MetadataMatcher();
         $metadataMatcher = $metadataMatcher->withMetadataMatch('int3', Operator::LOWER_THAN(), 1);
 
-        $this->eventStore->loadReverse($streamName, PHP_INT_MAX, null, $metadataMatcher);
+        $this->eventStore->loadReverse($streamName, null, null, $metadataMatcher);
 
         $this->assertFalse($result->valid());
 
         $metadataMatcher = new MetadataMatcher();
         $metadataMatcher = $metadataMatcher->withMetadataMatch('int4', Operator::LOWER_THAN_EQUALS(), 1);
 
-        $result = $this->eventStore->loadReverse($streamName, PHP_INT_MAX, null, $metadataMatcher);
+        $result = $this->eventStore->loadReverse($streamName, null, null, $metadataMatcher);
 
         $this->assertFalse($result->valid());
 

--- a/tests/Projection/InMemoryEventStoreProjectionTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectionTest.php
@@ -48,22 +48,6 @@ class InMemoryEventStoreProjectionTest extends AbstractEventStoreProjectionTest
     /**
      * @test
      */
-    public function it_deletes_when_projection_before_start_when_it_was_deleted_from_outside(): void
-    {
-        $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');
-    }
-
-    /**
-     * @test
-     */
-    public function it_deletes_incl_emitting_events_when_projection_before_start_when_it_was_deleted_from_outside(): void
-    {
-        $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');
-    }
-
-    /**
-     * @test
-     */
     public function it_deletes_projection_during_run_when_it_was_deleted_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');

--- a/tests/Projection/InMemoryEventStoreReadModelProjectionTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectionTest.php
@@ -49,14 +49,6 @@ class InMemoryEventStoreReadModelProjectionTest extends AbstractEventStoreReadMo
     /**
      * @test
      */
-    public function it_deletes_when_projection_before_start_when_it_was_deleted_from_outside(): void
-    {
-        $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');
-    }
-
-    /**
-     * @test
-     */
     public function it_deletes_projection_during_run_when_it_was_deleted_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');


### PR DESCRIPTION
I have replaces PHP_INT_MAX by null to test real usages for current implementation.

Also I have removed some skipped tests which should only overwrite tests from extended test case, which not longer there.

And small coverage increase.