### PR TITLE
adds a clustered events constant to event emitter event stores

### DIFF
--- a/examples/quickstart.php
+++ b/examples/quickstart.php
@@ -35,23 +35,7 @@ use Prooph\EventStore\TransactionalActionEventEmitterEventStore;
  * you write a wrapper for the event dispatcher used
  * by your web framework.
  */
-$eventEmitter = new ProophActionEventEmitter([
-    TransactionalActionEventEmitterEventStore::EVENT_APPEND_TO,
-    TransactionalActionEventEmitterEventStore::EVENT_CREATE,
-    TransactionalActionEventEmitterEventStore::EVENT_LOAD,
-    TransactionalActionEventEmitterEventStore::EVENT_LOAD_REVERSE,
-    TransactionalActionEventEmitterEventStore::EVENT_DELETE,
-    TransactionalActionEventEmitterEventStore::EVENT_HAS_STREAM,
-    TransactionalActionEventEmitterEventStore::EVENT_FETCH_STREAM_METADATA,
-    TransactionalActionEventEmitterEventStore::EVENT_UPDATE_STREAM_METADATA,
-    TransactionalActionEventEmitterEventStore::EVENT_FETCH_STREAM_NAMES,
-    TransactionalActionEventEmitterEventStore::EVENT_FETCH_STREAM_NAMES_REGEX,
-    TransactionalActionEventEmitterEventStore::EVENT_FETCH_CATEGORY_NAMES,
-    TransactionalActionEventEmitterEventStore::EVENT_FETCH_CATEGORY_NAMES_REGEX,
-    TransactionalActionEventEmitterEventStore::EVENT_BEGIN_TRANSACTION,
-    TransactionalActionEventEmitterEventStore::EVENT_COMMIT,
-    TransactionalActionEventEmitterEventStore::EVENT_ROLLBACK,
-]);
+$eventEmitter = new ProophActionEventEmitter(TransactionalActionEventEmitterEventStore::ALL_EVENTS);
 
 $eventStore = new ActionEventEmitterEventStore(new InMemoryEventStore(), $eventEmitter);
 

--- a/src/ActionEventEmitterEventStore.php
+++ b/src/ActionEventEmitterEventStore.php
@@ -37,6 +37,21 @@ class ActionEventEmitterEventStore implements EventStoreDecorator
     public const EVENT_FETCH_CATEGORY_NAMES = 'fetchCategoryNames';
     public const EVENT_FETCH_CATEGORY_NAMES_REGEX = 'fetchCategoryNamesRegex';
 
+    public const ALL_EVENTS = [
+        self::EVENT_APPEND_TO,
+        self::EVENT_CREATE,
+        self::EVENT_LOAD,
+        self::EVENT_LOAD_REVERSE,
+        self::EVENT_DELETE,
+        self::EVENT_HAS_STREAM,
+        self::EVENT_FETCH_STREAM_METADATA,
+        self::EVENT_UPDATE_STREAM_METADATA,
+        self::EVENT_FETCH_STREAM_NAMES,
+        self::EVENT_FETCH_STREAM_NAMES_REGEX,
+        self::EVENT_FETCH_CATEGORY_NAMES,
+        self::EVENT_FETCH_CATEGORY_NAMES_REGEX,
+    ];
+
     /**
      * @var ActionEventEmitter
      */

--- a/src/Container/InMemoryEventStoreFactory.php
+++ b/src/Container/InMemoryEventStoreFactory.php
@@ -86,23 +86,7 @@ final class InMemoryEventStoreFactory implements
         }
 
         if (! isset($config['event_emitter'])) {
-            $eventEmitter = new ProophActionEventEmitter([
-                TransactionalActionEventEmitterEventStore::EVENT_APPEND_TO,
-                TransactionalActionEventEmitterEventStore::EVENT_CREATE,
-                TransactionalActionEventEmitterEventStore::EVENT_LOAD,
-                TransactionalActionEventEmitterEventStore::EVENT_LOAD_REVERSE,
-                TransactionalActionEventEmitterEventStore::EVENT_DELETE,
-                TransactionalActionEventEmitterEventStore::EVENT_HAS_STREAM,
-                TransactionalActionEventEmitterEventStore::EVENT_FETCH_STREAM_METADATA,
-                TransactionalActionEventEmitterEventStore::EVENT_UPDATE_STREAM_METADATA,
-                TransactionalActionEventEmitterEventStore::EVENT_FETCH_STREAM_NAMES,
-                TransactionalActionEventEmitterEventStore::EVENT_FETCH_STREAM_NAMES_REGEX,
-                TransactionalActionEventEmitterEventStore::EVENT_FETCH_CATEGORY_NAMES,
-                TransactionalActionEventEmitterEventStore::EVENT_FETCH_CATEGORY_NAMES_REGEX,
-                TransactionalActionEventEmitterEventStore::EVENT_BEGIN_TRANSACTION,
-                TransactionalActionEventEmitterEventStore::EVENT_COMMIT,
-                TransactionalActionEventEmitterEventStore::EVENT_ROLLBACK,
-            ]);
+            $eventEmitter = new ProophActionEventEmitter(TransactionalActionEventEmitterEventStore::ALL_EVENTS);
         } else {
             $eventEmitter = $container->get($config['event_emitter']);
         }

--- a/src/TransactionalActionEventEmitterEventStore.php
+++ b/src/TransactionalActionEventEmitterEventStore.php
@@ -23,6 +23,24 @@ class TransactionalActionEventEmitterEventStore extends ActionEventEmitterEventS
     public const EVENT_COMMIT = 'commit';
     public const EVENT_ROLLBACK = 'rollback';
 
+    public const ALL_EVENTS = [
+        self::EVENT_APPEND_TO,
+        self::EVENT_CREATE,
+        self::EVENT_LOAD,
+        self::EVENT_LOAD_REVERSE,
+        self::EVENT_DELETE,
+        self::EVENT_HAS_STREAM,
+        self::EVENT_FETCH_STREAM_METADATA,
+        self::EVENT_UPDATE_STREAM_METADATA,
+        self::EVENT_FETCH_STREAM_NAMES,
+        self::EVENT_FETCH_STREAM_NAMES_REGEX,
+        self::EVENT_FETCH_CATEGORY_NAMES,
+        self::EVENT_FETCH_CATEGORY_NAMES_REGEX,
+        self::EVENT_BEGIN_TRANSACTION,
+        self::EVENT_COMMIT,
+        self::EVENT_ROLLBACK,
+    ];
+
     /**
      * @var TransactionalEventStore
      */

--- a/tests/ActionEventEmitterEventStoreTest.php
+++ b/tests/ActionEventEmitterEventStoreTest.php
@@ -85,20 +85,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->expectException(ConcurrencyException::class);
 
         $eventStore = $this->prophesize(EventStore::class);
-        $eventEmitter = new ProophActionEventEmitter([
-            ActionEventEmitterEventStore::EVENT_APPEND_TO,
-            ActionEventEmitterEventStore::EVENT_CREATE,
-            ActionEventEmitterEventStore::EVENT_LOAD,
-            ActionEventEmitterEventStore::EVENT_LOAD_REVERSE,
-            ActionEventEmitterEventStore::EVENT_DELETE,
-            ActionEventEmitterEventStore::EVENT_HAS_STREAM,
-            ActionEventEmitterEventStore::EVENT_FETCH_STREAM_METADATA,
-            ActionEventEmitterEventStore::EVENT_UPDATE_STREAM_METADATA,
-            ActionEventEmitterEventStore::EVENT_FETCH_STREAM_NAMES,
-            ActionEventEmitterEventStore::EVENT_FETCH_STREAM_NAMES_REGEX,
-            ActionEventEmitterEventStore::EVENT_FETCH_CATEGORY_NAMES,
-            ActionEventEmitterEventStore::EVENT_FETCH_CATEGORY_NAMES_REGEX,
-        ]);
+        $eventEmitter = new ProophActionEventEmitter(ActionEventEmitterEventStore::ALL_EVENTS);
 
         $actionEventStore = new ActionEventEmitterEventStore($eventStore->reveal(), $eventEmitter);
 

--- a/tests/ActionEventEmitterEventStoreTestCase.php
+++ b/tests/ActionEventEmitterEventStoreTestCase.php
@@ -26,20 +26,7 @@ abstract class ActionEventEmitterEventStoreTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $eventEmitter = new ProophActionEventEmitter([
-            ActionEventEmitterEventStore::EVENT_APPEND_TO,
-            ActionEventEmitterEventStore::EVENT_CREATE,
-            ActionEventEmitterEventStore::EVENT_LOAD,
-            ActionEventEmitterEventStore::EVENT_LOAD_REVERSE,
-            ActionEventEmitterEventStore::EVENT_DELETE,
-            ActionEventEmitterEventStore::EVENT_HAS_STREAM,
-            ActionEventEmitterEventStore::EVENT_FETCH_STREAM_METADATA,
-            ActionEventEmitterEventStore::EVENT_UPDATE_STREAM_METADATA,
-            ActionEventEmitterEventStore::EVENT_FETCH_STREAM_NAMES,
-            ActionEventEmitterEventStore::EVENT_FETCH_STREAM_NAMES_REGEX,
-            ActionEventEmitterEventStore::EVENT_FETCH_CATEGORY_NAMES,
-            ActionEventEmitterEventStore::EVENT_FETCH_CATEGORY_NAMES_REGEX,
-        ]);
+        $eventEmitter = new ProophActionEventEmitter(ActionEventEmitterEventStore::ALL_EVENTS);
 
         $this->eventStore = new ActionEventEmitterEventStore(new InMemoryEventStore(), $eventEmitter);
     }

--- a/tests/TransactionalActionEventEmitterEventStoreTest.php
+++ b/tests/TransactionalActionEventEmitterEventStoreTest.php
@@ -33,23 +33,7 @@ class TransactionalActionEventEmitterEventStoreTest extends TestCase
 
     protected function setUp(): void
     {
-        $eventEmitter = new ProophActionEventEmitter([
-            TransactionalActionEventEmitterEventStore::EVENT_APPEND_TO,
-            TransactionalActionEventEmitterEventStore::EVENT_CREATE,
-            TransactionalActionEventEmitterEventStore::EVENT_LOAD,
-            TransactionalActionEventEmitterEventStore::EVENT_LOAD_REVERSE,
-            TransactionalActionEventEmitterEventStore::EVENT_DELETE,
-            TransactionalActionEventEmitterEventStore::EVENT_HAS_STREAM,
-            TransactionalActionEventEmitterEventStore::EVENT_FETCH_STREAM_METADATA,
-            TransactionalActionEventEmitterEventStore::EVENT_UPDATE_STREAM_METADATA,
-            TransactionalActionEventEmitterEventStore::EVENT_FETCH_STREAM_NAMES,
-            TransactionalActionEventEmitterEventStore::EVENT_FETCH_STREAM_NAMES_REGEX,
-            TransactionalActionEventEmitterEventStore::EVENT_FETCH_CATEGORY_NAMES,
-            TransactionalActionEventEmitterEventStore::EVENT_FETCH_CATEGORY_NAMES_REGEX,
-            TransactionalActionEventEmitterEventStore::EVENT_BEGIN_TRANSACTION,
-            TransactionalActionEventEmitterEventStore::EVENT_COMMIT,
-            TransactionalActionEventEmitterEventStore::EVENT_ROLLBACK,
-        ]);
+        $eventEmitter = new ProophActionEventEmitter(TransactionalActionEventEmitterEventStore::ALL_EVENTS);
 
         $this->eventStore = new TransactionalActionEventEmitterEventStore(new InMemoryEventStore(), $eventEmitter);
     }


### PR DESCRIPTION
It is really annoying to find out all events I have to listen on, if I create a new event emitter instance.
Since this is also a part to change on some files on every release, I have added a constant which contains all available events.