### PR TITLE
Disallow PHP 7.1.3 because of Datetime bug (close #279)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "sandrokeil/interop-config": "For usage of provided factories"
     },
     "conflict": {
-        "sandrokeil/interop-config": "<2.0.1"
+        "sandrokeil/interop-config": "<2.0.1",
+        "php": "7.1.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I've used conflict section because I think it's more verbose.