### PR TITLE
Add projection option constants to trigger pcntl_signal_dispatch 

### DIFF
--- a/docs/projections.md
+++ b/docs/projections.md
@@ -145,6 +145,22 @@ OPTION_LOCK_TIMEOUT_MS = 'lock_timeout_ms'
 Indicates the time (in microseconds) the projector is locked. During this time no other projector with the same name can
 be started. A running projector will update the lock timeout on every loop.
 
+OPTION_PCNTL_DISPATCH = 'false'
+
+Enable dispatching of process signals to registered [signal handlers](http://php.net/manual/en/function.pcntl-signal.php) while
+the projection is running. You must still register your own signal handler and take according action.
+For example to gracefully stop the projection you could do
+```
+$projection = $projectionManager->createProjection(
+    'test_projection',
+    [ Projector::OPTION_PCNTL_DISPATCH => true, ]
+);
+pcntl_signal(SIGQUIT, function () use ($projection) {
+    $projection->stop();
+});
+$projection->run();
+```
+
 ## Read Model Projections
 
 Projections can also be used to create read models. A read model has to implement `Prooph\EventStore\Projection\ReadModel`.

--- a/src/Projection/InMemoryEventStoreProjector.php
+++ b/src/Projection/InMemoryEventStoreProjector.php
@@ -112,8 +112,7 @@ final class InMemoryEventStoreProjector implements Projector
         int $cacheSize,
         int $sleep,
         bool $triggerPcntlSignalDispatch = false
-    )
-    {
+    ) {
         if ($cacheSize < 1) {
             throw new Exception\InvalidArgumentException('cache size must be a positive integer');
         }
@@ -359,7 +358,6 @@ final class InMemoryEventStoreProjector implements Projector
             }
 
             $this->triggerPcntlSignalDispatch();
-
         } while ($keepRunning && ! $this->isStopped);
 
         $this->status = ProjectionStatus::IDLE();

--- a/src/Projection/InMemoryEventStoreReadModelProjector.php
+++ b/src/Projection/InMemoryEventStoreReadModelProjector.php
@@ -326,7 +326,6 @@ final class InMemoryEventStoreReadModelProjector implements ReadModelProjector
             }
 
             $this->triggerPcntlSignalDispatch();
-
         } while ($keepRunning && ! $this->isStopped);
 
         $this->status = ProjectionStatus::IDLE();

--- a/src/Projection/InMemoryProjectionManager.php
+++ b/src/Projection/InMemoryProjectionManager.php
@@ -58,7 +58,8 @@ final class InMemoryProjectionManager implements ProjectionManager
             $this->eventStore,
             $name,
             $options[Projector::OPTION_CACHE_SIZE] ?? Projector::DEFAULT_CACHE_SIZE,
-            $options[Projector::OPTION_SLEEP] ?? Projector::DEFAULT_SLEEP
+            $options[Projector::OPTION_SLEEP] ?? Projector::DEFAULT_SLEEP,
+            $options[Projector::OPTION_PCNTL_DISPATCH] ?? Projector::DEFAULT_PCNTL_DISPATCH
         );
 
         if (! isset($this->projectors[$name])) {
@@ -79,7 +80,8 @@ final class InMemoryProjectionManager implements ProjectionManager
             $readModel,
             $options[ReadModelProjector::OPTION_CACHE_SIZE] ?? ReadModelProjector::DEFAULT_CACHE_SIZE,
             $options[ReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? ReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
-            $options[ReadModelProjector::OPTION_SLEEP] ?? ReadModelProjector::DEFAULT_SLEEP
+            $options[ReadModelProjector::OPTION_SLEEP] ?? ReadModelProjector::DEFAULT_SLEEP,
+            $options[ReadModelProjector::OPTION_PCNTL_DISPATCH] ?? ReadModelProjector::DEFAULT_PCNTL_DISPATCH
         );
 
         if (! isset($this->projectors[$name])) {

--- a/src/Projection/Projector.php
+++ b/src/Projection/Projector.php
@@ -21,11 +21,13 @@ interface Projector
     public const OPTION_SLEEP = 'sleep';
     public const OPTION_PERSIST_BLOCK_SIZE = 'persist_block_size';
     public const OPTION_LOCK_TIMEOUT_MS = 'lock_timeout_ms';
+    public const OPTION_PCNTL_DISPATCH = 'trigger_pcntl_dispatch';
 
     public const DEFAULT_CACHE_SIZE = 1000;
     public const DEFAULT_SLEEP = 100000;
     public const DEFAULT_PERSIST_BLOCK_SIZE = 1000;
     public const DEFAULT_LOCK_TIMEOUT_MS = 1000;
+    public const DEFAULT_PCNTL_DISPATCH = false;
 
     /**
      * The callback has to return an array

--- a/src/Projection/ReadModelProjector.php
+++ b/src/Projection/ReadModelProjector.php
@@ -20,11 +20,13 @@ interface ReadModelProjector
     public const OPTION_SLEEP = 'sleep';
     public const OPTION_PERSIST_BLOCK_SIZE = 'persist_block_size';
     public const OPTION_LOCK_TIMEOUT_MS = 'lock_timeout_ms';
+    public const OPTION_PCNTL_DISPATCH = 'trigger_pcntl_dispatch';
 
     public const DEFAULT_CACHE_SIZE = 1000;
     public const DEFAULT_SLEEP = 100000;
     public const DEFAULT_PERSIST_BLOCK_SIZE = 1000;
     public const DEFAULT_LOCK_TIMEOUT_MS = 1000;
+    public const DEFAULT_PCNTL_DISPATCH = false;
 
     /**
      * The callback has to return an array

--- a/tests/Projection/InMemoryEventStoreProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectorTest.php
@@ -160,7 +160,7 @@ class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
      */
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {
-        if ( !extension_loaded('pcntl')) {
+        if (! extension_loaded('pcntl')) {
             $this->markTestSkipped('The PCNTL extension is not available.');
 
             return;

--- a/tests/Projection/InMemoryEventStoreProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectorTest.php
@@ -118,7 +118,7 @@ class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
 
         $eventStore = $this->prophesize(EventStore::class);
 
-        new InMemoryEventStoreProjector($eventStore->reveal(), 'test_projection', 10, 10, 2000);
+        new InMemoryEventStoreProjector($eventStore->reveal(), 'test_projection', 10, 10);
     }
 
     /**

--- a/tests/Projection/InMemoryEventStoreProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectorTest.php
@@ -160,8 +160,9 @@ class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
      */
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {
-        if (!extension_loaded('pcntl')) {
+        if ( !extension_loaded('pcntl')) {
             $this->markTestSkipped('The PCNTL extension is not available.');
+
             return;
         }
 

--- a/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
@@ -165,4 +165,37 @@ class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadMod
 
         new InMemoryEventStoreReadModelProjector($wrappedEventStore->reveal(), 'test_projection', new ReadModelMock(), 1, 1, 1);
     }
+
+    /**
+     * @test
+     */
+    public function it_dispatches_pcntl_signals_when_enabled(): void
+    {
+        if (!extension_loaded('pcntl')) {
+            $this->markTestSkipped('The PCNTL extension is not available.');
+            return;
+        }
+
+        $command = 'php ' . realpath(__DIR__) . '/isolated-read-model-projection.php';
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        /**
+         * Created process inherits env variables from this process.
+         * Script returns with non-standard code SIGUSR1 from the handler and -1 else
+         */
+        $projectionProcess = proc_open($command, $descriptorSpec, $pipes);
+        $processDetails = proc_get_status($projectionProcess);
+        sleep(2);
+        posix_kill($processDetails['pid'], SIGQUIT);
+        sleep(2);
+
+        $processDetails = proc_get_status($projectionProcess);
+        $this->assertEquals(
+            SIGUSR1,
+            $processDetails['exitcode']
+        );
+    }
 }

--- a/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
@@ -171,8 +171,9 @@ class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadMod
      */
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {
-        if (!extension_loaded('pcntl')) {
+        if ( !extension_loaded('pcntl')) {
             $this->markTestSkipped('The PCNTL extension is not available.');
+
             return;
         }
 

--- a/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
@@ -171,7 +171,7 @@ class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadMod
      */
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {
-        if ( !extension_loaded('pcntl')) {
+        if (! extension_loaded('pcntl')) {
             $this->markTestSkipped('The PCNTL extension is not available.');
 
             return;

--- a/tests/Projection/isolated-projection.php
+++ b/tests/Projection/isolated-projection.php
@@ -1,0 +1,28 @@
+<?php
+
+use Prooph\EventStore\InMemoryEventStore;
+use Prooph\EventStore\Projection\InMemoryProjectionManager;
+use Prooph\EventStore\Projection\Projector;
+use Prooph\EventStore\Stream;
+use Prooph\EventStore\StreamName;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$eventStore = new InMemoryEventStore();
+$eventStore->create(new Stream(new StreamName('user-123'), new ArrayIterator([])));
+
+$projectionManager = new InMemoryProjectionManager($eventStore);
+$projection = $projectionManager->createProjection(
+    'test_projection',
+    [
+        Projector::OPTION_PCNTL_DISPATCH => true
+    ]
+);
+pcntl_signal(SIGQUIT, function () use ($projection) {
+    $projection->stop();
+    exit(SIGUSR1);
+});
+$projection
+    ->fromStream('user-123')
+    ->whenAny(function () {})
+    ->run();

--- a/tests/Projection/isolated-projection.php
+++ b/tests/Projection/isolated-projection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
 use Prooph\EventStore\Projection\Projector;
@@ -15,7 +17,7 @@ $projectionManager = new InMemoryProjectionManager($eventStore);
 $projection = $projectionManager->createProjection(
     'test_projection',
     [
-        Projector::OPTION_PCNTL_DISPATCH => true
+        Projector::OPTION_PCNTL_DISPATCH => true,
     ]
 );
 pcntl_signal(SIGQUIT, function () use ($projection) {
@@ -24,5 +26,6 @@ pcntl_signal(SIGQUIT, function () use ($projection) {
 });
 $projection
     ->fromStream('user-123')
-    ->whenAny(function () {})
+    ->whenAny(function () {
+    })
     ->run();

--- a/tests/Projection/isolated-read-model-projection.php
+++ b/tests/Projection/isolated-read-model-projection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
 use Prooph\EventStore\Projection\ReadModel;
@@ -44,7 +46,7 @@ $projection = $projectionManager->createReadModelProjection(
     'test_projection',
     $readModel,
     [
-        ReadModelProjector::OPTION_PCNTL_DISPATCH => true
+        ReadModelProjector::OPTION_PCNTL_DISPATCH => true,
     ]
 );
 pcntl_signal(SIGQUIT, function () use ($projection) {
@@ -53,5 +55,6 @@ pcntl_signal(SIGQUIT, function () use ($projection) {
 });
 $projection
     ->fromStream('user-123')
-    ->whenAny(function () {})
+    ->whenAny(function () {
+    })
     ->run();

--- a/tests/Projection/isolated-read-model-projection.php
+++ b/tests/Projection/isolated-read-model-projection.php
@@ -1,0 +1,57 @@
+<?php
+
+use Prooph\EventStore\InMemoryEventStore;
+use Prooph\EventStore\Projection\InMemoryProjectionManager;
+use Prooph\EventStore\Projection\ReadModel;
+use Prooph\EventStore\Projection\ReadModelProjector;
+use Prooph\EventStore\Stream;
+use Prooph\EventStore\StreamName;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$readModel = new class() implements ReadModel {
+    public function init(): void
+    {
+    }
+
+    public function isInitialized(): bool
+    {
+        return true;
+    }
+
+    public function reset(): void
+    {
+    }
+
+    public function delete(): void
+    {
+    }
+
+    public function stack(string $operation, ...$args): void
+    {
+    }
+
+    public function persist(): void
+    {
+    }
+};
+
+$eventStore = new InMemoryEventStore();
+$eventStore->create(new Stream(new StreamName('user-123'), new ArrayIterator([])));
+
+$projectionManager = new InMemoryProjectionManager($eventStore);
+$projection = $projectionManager->createReadModelProjection(
+    'test_projection',
+    $readModel,
+    [
+        ReadModelProjector::OPTION_PCNTL_DISPATCH => true
+    ]
+);
+pcntl_signal(SIGQUIT, function () use ($projection) {
+    $projection->stop();
+    exit(SIGUSR1);
+});
+$projection
+    ->fromStream('user-123')
+    ->whenAny(function () {})
+    ->run();


### PR DESCRIPTION
Moving these constants to the generic interface as discussed [here ](https://github.com/prooph/pdo-event-store/pull/96). Will update the other PR with the new minimum version constraint once this has been merged and released as a new version.