### PR TITLE
Catch Throwable in transactional()

### DIFF
--- a/src/InMemoryEventStore.php
+++ b/src/InMemoryEventStore.php
@@ -265,7 +265,7 @@ final class InMemoryEventStore implements TransactionalEventStore
         try {
             $result = $callable($this);
             $this->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->rollback();
             throw $e;
         }


### PR DESCRIPTION
Fixes the same problem as in prooph/pdo-event-store#111 