### PR TITLE
Fix exception in InMemoryEventStoreReadModelProjector

### DIFF
--- a/src/Projection/InMemoryEventStoreReadModelProjector.php
+++ b/src/Projection/InMemoryEventStoreReadModelProjector.php
@@ -472,7 +472,7 @@ final class InMemoryEventStoreReadModelProjector implements ReadModelProjector
         $reflectionProperty->setAccessible(true);
 
         $streamPositions = [];
-        $streams = array_keys($reflectionProperty->getValue($this->eventStore));
+        $streams = array_keys($reflectionProperty->getValue($this->innerEventStore));
 
         if (isset($this->query['all'])) {
             foreach ($streams as $stream) {


### PR DESCRIPTION
In the current implementation if `$this->eventStore` and `$this->innerEventStore` are different instances PHP throws this exception:

```
[ReflectionException]                                                      
Given object is not an instance of the class this property was declared in
```