### PR TITLE
fixed metadata enum class doc-blocks

### DIFF
--- a/src/Metadata/FieldType.php
+++ b/src/Metadata/FieldType.php
@@ -15,8 +15,8 @@ namespace Prooph\EventStore\Metadata;
 use MabeEnum\Enum;
 
 /**
- * @method static FieldType METADATA
- * @method static FieldType MESSAGE_PROPERTY
+ * @method static FieldType METADATA()
+ * @method static FieldType MESSAGE_PROPERTY()
  */
 final class FieldType extends Enum
 {

--- a/src/Metadata/Operator.php
+++ b/src/Metadata/Operator.php
@@ -15,15 +15,15 @@ namespace Prooph\EventStore\Metadata;
 use MabeEnum\Enum;
 
 /**
- * @method static Operator EQUALS
- * @method static Operator GREATER_THAN
- * @method static Operator GREATER_THAN_EQUALS
- * @method static Operator IN
- * @method static Operator LOWER_THAN
- * @method static Operator LOWER_THAN_EQUALS
- * @method static Operator NOT_EQUALS
- * @method static Operator NOT_IN
- * @method static Operator REGEX
+ * @method static Operator EQUALS()
+ * @method static Operator GREATER_THAN()
+ * @method static Operator GREATER_THAN_EQUALS()
+ * @method static Operator IN()
+ * @method static Operator LOWER_THAN()
+ * @method static Operator LOWER_THAN_EQUALS()
+ * @method static Operator NOT_EQUALS()
+ * @method static Operator NOT_IN()
+ * @method static Operator REGEX()
  */
 class Operator extends Enum
 {


### PR DESCRIPTION
Fixed metadata enum class doc-blocks according to https://docs.phpdoc.org/references/phpdoc/tags/method.html.
Super minor change, but breaks PHPStan analysis if these classes are used in project.