### PR TITLE
Add projection option update lock threshold

### DIFF
--- a/src/Projection/Projector.php
+++ b/src/Projection/Projector.php
@@ -22,12 +22,14 @@ interface Projector
     public const OPTION_PERSIST_BLOCK_SIZE = 'persist_block_size';
     public const OPTION_LOCK_TIMEOUT_MS = 'lock_timeout_ms';
     public const OPTION_PCNTL_DISPATCH = 'trigger_pcntl_dispatch';
+    public const OPTION_UPDATE_LOCK_THRESHOLD = 'update_lock_threshold';
 
     public const DEFAULT_CACHE_SIZE = 1000;
     public const DEFAULT_SLEEP = 100000;
     public const DEFAULT_PERSIST_BLOCK_SIZE = 1000;
     public const DEFAULT_LOCK_TIMEOUT_MS = 1000;
     public const DEFAULT_PCNTL_DISPATCH = false;
+    public const DEFAULT_UPDATE_LOCK_THRESHOLD = 0;
 
     /**
      * The callback has to return an array


### PR DESCRIPTION
See updated docs for reasons.
Default value of the new projection option is 0, so existing projections are not effected by this new optional config param.