### PR TITLE
Improve DateTime::create()

### DIFF
--- a/src/Util/DateTime.php
+++ b/src/Util/DateTime.php
@@ -15,6 +15,7 @@ namespace Prooph\EventStore\Util;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use InvalidArgumentException;
 
 class DateTime
 {
@@ -25,11 +26,22 @@ class DateTime
 
     public static function create(string $dateTimeString): DateTimeImmutable
     {
-        return DateTimeImmutable::createFromFormat(
+        $dateTime = DateTimeImmutable::createFromFormat(
             'Y-m-d\TH:i:s.uP',
             $dateTimeString,
             new DateTimeZone('UTC')
         );
+
+        if ($dateTime === false) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Could not create DateTimeImmutable from string "%s".',
+                    $dateTimeString
+                )
+            );
+        }
+
+        return $dateTime;
     }
 
     public static function format(DateTimeImmutable $dateTime): string

--- a/src/Util/DateTime.php
+++ b/src/Util/DateTime.php
@@ -34,7 +34,7 @@ class DateTime
 
         if ($dateTime === false) {
             throw new InvalidArgumentException(
-                sprintf(
+                \sprintf(
                     'Could not create DateTimeImmutable from string "%s".',
                     $dateTimeString
                 )


### PR DESCRIPTION
```
TypeError(code: 0): Return value of Prooph\\EventStore\\Util\\DateTime::create() must be an instance of DateTimeImmutable, bool returned at /usr/app/vendor/prooph/event-store/src/Util/DateTime.php:31
```

I know this should not happen but it did happen for me. Unfortunately it's not easy to reproduce and I don't have the string nor the stack trace. This should help me debug any future cases.