### PR TITLE
Fix DateTime parsing

### DIFF
--- a/src/Util/DateTime.php
+++ b/src/Util/DateTime.php
@@ -32,6 +32,15 @@ class DateTime
             new DateTimeZone('UTC')
         );
 
+        // Workaround for https://github.com/EventStore/EventStore/issues/1903.
+        if ($dateTime === false) {
+            $dateTime = DateTimeImmutable::createFromFormat(
+                'Y-m-d\TH:i:sP',
+                $dateTimeString,
+                new DateTimeZone('UTC')
+            );
+        }
+
         if ($dateTime === false) {
             throw new InvalidArgumentException(
                 \sprintf(


### PR DESCRIPTION
EventStore's HTTP API sometimes returns a datetime in different format. See https://github.com/EventStore/EventStore/issues/1903 for details.