### PR TITLE
Improvement/merged stream iterator

### DIFF
--- a/src/StreamIterator/MergedStreamIterator.php
+++ b/src/StreamIterator/MergedStreamIterator.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This file is part of prooph/event-store.
+ * (c) 2014-2019 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2019 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\StreamIterator;
+
+use Countable;
+use Prooph\Common\Messaging\Message;
+
+class MergedStreamIterator implements StreamIterator
+{
+    /**
+     * @var StreamIterator[]
+     */
+    private $iterators;
+
+    /**
+     * @var integer
+     */
+    private $index = 0;
+
+    public function __construct(StreamIterator ...$iterators)
+    {
+        $this->iterators = [];
+
+        foreach ($iterators as $key => $iterator) {
+            $this->iterators[$key] = $iterator;
+        }
+
+        $this->prioritizeIterators();
+    }
+
+    public function rewind(): void
+    {
+        foreach ($this->iterators as $iter) {
+            $iter->rewind();
+        }
+
+        $this->index = 0;
+
+        $this->prioritizeIterators();
+    }
+
+    public function valid(): bool
+    {
+        foreach ($this->iterators as $key => $iterator) {
+            if ($iterator->valid()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function next(): void
+    {
+        // only advance the prioritized iterator
+        $this->iterators[\array_keys($this->iterators)[0]]->next();
+
+        $this->index++;
+
+        $this->prioritizeIterators();
+    }
+
+    public function current()
+    {
+        return $this->iterators[\array_keys($this->iterators)[0]]->current();
+    }
+
+    public function key(): int
+    {
+        return $this->index;
+    }
+
+    public function count(): int
+    {
+        $count = 0;
+        foreach ($this->iterators as $iterator) {
+            if ($iterator instanceof Countable) {
+                $count += \count($iterator);
+            } else {
+                $count += \iterator_count($iterator);
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Will prioritize iterators via sorting them according to;
+     *
+     * 1) invalid iterators are placed last.
+     * 2) by comparing the createdAt of the current prooph message of the iterator.
+     */
+    private function prioritizeIterators(): void
+    {
+        $compareValue = function (\Iterator $iterator): \DateTimeImmutable {
+            /** @var Message $message */
+            $message = $iterator->current();
+
+            return $message->createdAt();
+        };
+
+        $compareFunction = function (\Iterator $a, \Iterator $b) use ($compareValue) {
+            // valid iterators should be prioritized over invalid ones
+            if (! $a->valid() or ! $b->valid()) {
+                return $b->valid() <=> $a->valid();
+            }
+
+            return $compareValue($a) <=> $compareValue($b);
+        };
+
+        \uasort($this->iterators, $compareFunction);
+    }
+}

--- a/src/StreamIterator/MergedStreamIterator.php
+++ b/src/StreamIterator/MergedStreamIterator.php
@@ -24,13 +24,19 @@ class MergedStreamIterator implements StreamIterator
     private $iterators;
 
     /**
+     * @var string[]
+     */
+    private $streamNames;
+
+    /**
      * @var integer
      */
     private $index = 0;
 
-    public function __construct(StreamIterator ...$iterators)
+    public function __construct(array $streamNames, StreamIterator ...$iterators)
     {
         $this->iterators = [];
+        $this->streamNames = $streamNames;
 
         foreach ($iterators as $key => $iterator) {
             $this->iterators[$key] = $iterator;
@@ -74,6 +80,11 @@ class MergedStreamIterator implements StreamIterator
     public function current()
     {
         return $this->iterators[\array_keys($this->iterators)[0]]->current();
+    }
+
+    public function streamName(): string
+    {
+        return $this->streamNames[\array_keys($this->iterators)[0]];
     }
 
     public function key(): int

--- a/src/StreamIterator/MergedStreamIterator.php
+++ b/src/StreamIterator/MergedStreamIterator.php
@@ -27,11 +27,6 @@ class MergedStreamIterator implements StreamIterator
      */
     private $streamNames;
 
-    /**
-     * @var integer
-     */
-    private $index = 0;
-
     public function __construct(array $streamNames, StreamIterator ...$iterators)
     {
         $this->iterators = [];
@@ -49,8 +44,6 @@ class MergedStreamIterator implements StreamIterator
         foreach ($this->iterators as $iter) {
             $iter->rewind();
         }
-
-        $this->index = 0;
 
         $this->prioritizeIterators();
     }
@@ -71,8 +64,6 @@ class MergedStreamIterator implements StreamIterator
         // only advance the prioritized iterator
         $this->iterators[\array_keys($this->iterators)[0]]->next();
 
-        $this->index++;
-
         $this->prioritizeIterators();
     }
 
@@ -88,7 +79,7 @@ class MergedStreamIterator implements StreamIterator
 
     public function key(): int
     {
-        return $this->index;
+        return $this->iterators[\array_keys($this->iterators)[0]]->key();
     }
 
     public function count(): int

--- a/src/StreamIterator/MergedStreamIterator.php
+++ b/src/StreamIterator/MergedStreamIterator.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Prooph\EventStore\StreamIterator;
 
-use Countable;
 use Prooph\Common\Messaging\Message;
 
 class MergedStreamIterator implements StreamIterator
@@ -96,11 +95,7 @@ class MergedStreamIterator implements StreamIterator
     {
         $count = 0;
         foreach ($this->iterators as $iterator) {
-            if ($iterator instanceof Countable) {
-                $count += \count($iterator);
-            } else {
-                $count += \iterator_count($iterator);
-            }
+            $count += \count($iterator);
         }
 
         return $count;

--- a/tests/StreamIterator/MergedStreamIteratorTest.php
+++ b/tests/StreamIterator/MergedStreamIteratorTest.php
@@ -25,19 +25,19 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
     {
         return [
             'streamA' => new InMemoryStreamIterator([
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 5, 'expected_stream_name' => 'streamA'], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388510')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 7, 'expected_stream_name' => 'streamA'], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388519')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 8, 'expected_stream_name' => 'streamA'], 3, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388520')),
+                1 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 5, 'expected_position' => 1, 'expected_stream_name' => 'streamA'], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388510')),
+                2 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 7, 'expected_position' => 2, 'expected_stream_name' => 'streamA'], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388519')),
+                3 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 8, 'expected_position' => 3, 'expected_stream_name' => 'streamA'], 3, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388520')),
             ]),
             'streamB' => new InMemoryStreamIterator([
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 1, 'expected_stream_name' => 'streamB'], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388501')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 2, 'expected_stream_name' => 'streamB'], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388503')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 4, 'expected_stream_name' => 'streamB'], 3, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388509')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 6, 'expected_stream_name' => 'streamB'], 4, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388515')),
+                1 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 1, 'expected_position' => 1, 'expected_stream_name' => 'streamB'], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388501')),
+                2 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 2, 'expected_position' => 2, 'expected_stream_name' => 'streamB'], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388503')),
+                3 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 4, 'expected_position' => 3, 'expected_stream_name' => 'streamB'], 3, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388509')),
+                4 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 6, 'expected_position' => 4, 'expected_stream_name' => 'streamB'], 4, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388515')),
             ]),
             'streamC' => new InMemoryStreamIterator([
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 0, 'expected_stream_name' => 'streamC'], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388500')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 3, 'expected_stream_name' => 'streamC'], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388503')),
+                1 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 0, 'expected_position' => 1, 'expected_stream_name' => 'streamC'], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388500')),
+                2 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 3, 'expected_position' => 2, 'expected_stream_name' => 'streamC'], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388503')),
             ]),
         ];
     }
@@ -85,9 +85,36 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
     {
         $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
 
-        foreach ($iterator as $key => $message) {
-            $this->assertEquals($key, $message->payload()['expected_index']);
+        $index = 0;
+        foreach ($iterator as $position => $message) {
+            $this->assertEquals($index, $message->payload()['expected_index']);
             $this->assertEquals($iterator->streamName(), $message->payload()['expected_stream_name']);
+
+            $index++;
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_correct_stream_name(): void
+    {
+        $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
+
+        foreach ($iterator as $position => $message) {
+            $this->assertEquals($iterator->streamName(), $message->payload()['expected_stream_name']);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function key_represents_event_position(): void
+    {
+        $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
+
+        foreach ($iterator as $position => $message) {
+            $this->assertEquals($position, $message->payload()['expected_position']);
         }
     }
 }

--- a/tests/StreamIterator/MergedStreamIteratorTest.php
+++ b/tests/StreamIterator/MergedStreamIteratorTest.php
@@ -43,7 +43,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
     }
 
     /**
-     * test
+     * @test
      */
     public function it_implements_stream_iterator(): void
     {
@@ -53,7 +53,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
     }
 
     /**
-     * test
+     * @test
      */
     public function it_counts_correct(): void
     {

--- a/tests/StreamIterator/MergedStreamIteratorTest.php
+++ b/tests/StreamIterator/MergedStreamIteratorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of prooph/event-store.
+ * (c) 2014-2019 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2019 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\StreamIterator;
+
+use DateTimeImmutable;
+use Prooph\EventStore\StreamIterator\InMemoryStreamIterator;
+use Prooph\EventStore\StreamIterator\MergedStreamIterator;
+use Prooph\EventStore\StreamIterator\StreamIterator;
+use ProophTest\EventStore\Mock\TestDomainEvent;
+
+class MergedStreamIteratorTest extends AbstractStreamIteratorTest
+{
+    public function getStreams(): array
+    {
+        return [
+            new InMemoryStreamIterator([
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 5], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388510')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 7], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388519')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 8], 3, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388520')),
+            ]),
+            new InMemoryStreamIterator([
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 1], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388501')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 2], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388503')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 4], 3, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388509')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 6], 4, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388515')),
+            ]),
+            new InMemoryStreamIterator([
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 0], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388500')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 3], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388503')),
+            ]),
+        ];
+    }
+
+    /**
+     * test
+     */
+    public function it_implements_stream_iterator(): void
+    {
+        $iterator = new MergedStreamIterator(...$this->getStreams());
+
+        $this->assertInstanceOf(StreamIterator::class, $iterator);
+    }
+
+    /**
+     * test
+     */
+    public function it_counts_correct(): void
+    {
+        $iterator = new MergedStreamIterator(...$this->getStreams());
+
+        $this->assertEquals(8, $iterator->count());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_rewind(): void
+    {
+        $iterator = new MergedStreamIterator(...$this->getStreams());
+
+        $iterator->next();
+
+        $iterator->rewind();
+
+        $message = $iterator->current();
+
+        $this->assertEquals(0, $message->payload()['expected_index']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_messages_in_order(): void
+    {
+        $iterator = new MergedStreamIterator(...$this->getStreams());
+
+        foreach ($iterator as $key => $message) {
+            $this->assertEquals($key, $message->payload()['expected_index']);
+        }
+    }
+}

--- a/tests/StreamIterator/MergedStreamIteratorTest.php
+++ b/tests/StreamIterator/MergedStreamIteratorTest.php
@@ -24,20 +24,20 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
     public function getStreams(): array
     {
         return [
-            new InMemoryStreamIterator([
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 5], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388510')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 7], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388519')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 8], 3, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388520')),
+            'streamA' => new InMemoryStreamIterator([
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 5, 'expected_stream_name' => 'streamA'], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388510')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 7, 'expected_stream_name' => 'streamA'], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388519')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 8, 'expected_stream_name' => 'streamA'], 3, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388520')),
             ]),
-            new InMemoryStreamIterator([
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 1], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388501')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 2], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388503')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 4], 3, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388509')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 6], 4, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388515')),
+            'streamB' => new InMemoryStreamIterator([
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 1, 'expected_stream_name' => 'streamB'], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388501')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 2, 'expected_stream_name' => 'streamB'], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388503')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 4, 'expected_stream_name' => 'streamB'], 3, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388509')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 6, 'expected_stream_name' => 'streamB'], 4, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388515')),
             ]),
-            new InMemoryStreamIterator([
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 0], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388500')),
-                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 3], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388503')),
+            'streamC' => new InMemoryStreamIterator([
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 0, 'expected_stream_name' => 'streamC'], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388500')),
+                TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 3, 'expected_stream_name' => 'streamC'], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2019-05-10T10:18:19.388503')),
             ]),
         ];
     }
@@ -47,7 +47,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
      */
     public function it_implements_stream_iterator(): void
     {
-        $iterator = new MergedStreamIterator(...$this->getStreams());
+        $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
 
         $this->assertInstanceOf(StreamIterator::class, $iterator);
     }
@@ -57,7 +57,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
      */
     public function it_counts_correct(): void
     {
-        $iterator = new MergedStreamIterator(...$this->getStreams());
+        $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
 
         $this->assertEquals(8, $iterator->count());
     }
@@ -67,7 +67,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
      */
     public function it_can_rewind(): void
     {
-        $iterator = new MergedStreamIterator(...$this->getStreams());
+        $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
 
         $iterator->next();
 
@@ -83,10 +83,11 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
      */
     public function it_returns_messages_in_order(): void
     {
-        $iterator = new MergedStreamIterator(...$this->getStreams());
+        $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
 
         foreach ($iterator as $key => $message) {
             $this->assertEquals($key, $message->payload()['expected_index']);
+            $this->assertEquals($iterator->streamName(), $message->payload()['expected_stream_name']);
         }
     }
 }

--- a/tests/StreamIterator/MergedStreamIteratorTest.php
+++ b/tests/StreamIterator/MergedStreamIteratorTest.php
@@ -59,7 +59,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
     {
         $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
 
-        $this->assertEquals(8, $iterator->count());
+        $this->assertEquals(9, $iterator->count());
     }
 
     /**


### PR DESCRIPTION
implementation of https://github.com/prooph/pdo-event-store/issues/201

some notes;
- works like any other iterator (no array result from current with results from multiple iterators)
- can work with any number of streams (but not zero)
- can query for streamName of `current` message (needed for tracking of projection positions)
- invalid iterators may become valid again while still iterating other valid ones without problem
- think it should be still fastish
