### PR TITLE
Remove workaround in DateTime parsing

### DIFF
--- a/src/Util/DateTime.php
+++ b/src/Util/DateTime.php
@@ -32,15 +32,6 @@ class DateTime
             new DateTimeZone('UTC')
         );
 
-        // Workaround for https://github.com/EventStore/EventStore/issues/1903.
-        if ($dateTime === false) {
-            $dateTime = DateTimeImmutable::createFromFormat(
-                'Y-m-d\TH:i:sP',
-                $dateTimeString,
-                new DateTimeZone('UTC')
-            );
-        }
-
         if ($dateTime === false) {
             throw new InvalidArgumentException(
                 \sprintf(


### PR DESCRIPTION
This workaround has now been moved to the HTTP client, as the problem only exists with HTTP API of the event store. See https://github.com/prooph/event-store-http-client/pull/42