### PR TITLE
Fix subsequent messages raised within upcasting chain

### DIFF
--- a/src/Upcasting/UpcasterChain.php
+++ b/src/Upcasting/UpcasterChain.php
@@ -36,7 +36,7 @@ final class UpcasterChain implements Upcaster
             $result = [];
 
             foreach ($messages as $message) {
-                $result = array_merge($result, $upcaster->upcast($message));
+                $result = \array_merge($result, $upcaster->upcast($message));
             }
 
             $messages = $result;

--- a/src/Upcasting/UpcasterChain.php
+++ b/src/Upcasting/UpcasterChain.php
@@ -36,7 +36,7 @@ final class UpcasterChain implements Upcaster
             $result = [];
 
             foreach ($messages as $message) {
-                $result += $upcaster->upcast($message);
+                $result = array_merge($result, $upcaster->upcast($message));
             }
 
             $messages = $result;

--- a/tests/Upcasting/UpcasterChainTest.php
+++ b/tests/Upcasting/UpcasterChainTest.php
@@ -17,7 +17,9 @@ use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\Upcasting\NoOpEventUpcaster;
 use Prooph\EventStore\Upcasting\SingleEventUpcaster;
+use Prooph\EventStore\Upcasting\Upcaster;
 use Prooph\EventStore\Upcasting\UpcasterChain;
+use Prophecy\Argument;
 
 class UpcasterChainTest extends TestCase
 {
@@ -53,6 +55,60 @@ class UpcasterChainTest extends TestCase
         $this->assertNotEmpty($messages);
         $this->assertSame($upcastedMessage2, $messages[0]);
         $this->assertSame($upcastedMessage3, $messages[1]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_doesnt_remove_messages_when_a_subsequent_upcaster_returns_fewer_messages()
+    {
+        $initialMessage = $this->prophesize(Message::class);
+        $initialMessage->payload()->willReturn(['name' => 'initialMessage']);
+        $initialMessage = $initialMessage->reveal();
+
+        $subsequentMessage = $this->prophesize(Message::class);
+        $subsequentMessage->payload()->willReturn(['name' => 'subsequentMessage']);
+        $subsequentMessage = $subsequentMessage->reveal();
+
+        $modifiedSubsequentMessage = $this->prophesize(Message::class);
+        $modifiedSubsequentMessage->payload()->willReturn(['name' => 'subsequentMessage-modified']);
+        $modifiedSubsequentMessage = $modifiedSubsequentMessage->reveal();
+
+        $furtherSubsequentMessage = $this->prophesize(Message::class);
+        $furtherSubsequentMessage->payload()->willReturn(['name' => 'furtherSubsequentMessage']);
+        $furtherSubsequentMessage = $furtherSubsequentMessage->reveal();
+
+        $upcasterOne = $this->prophesize(Upcaster::class);
+        $upcasterOne->upcast($initialMessage)->willReturn([$initialMessage]);
+
+        $upcasterTwo = $this->prophesize(Upcaster::class);
+        $upcasterTwo->upcast($initialMessage)->willReturn([$initialMessage, $subsequentMessage]);
+
+        $upcasterThree = $this->prophesize(Upcaster::class);
+        $upcasterThree->upcast($initialMessage)->willReturn([$initialMessage]);
+        $upcasterThree->upcast($subsequentMessage)->willReturn([$modifiedSubsequentMessage, $furtherSubsequentMessage]);
+
+        $upcasterFour = new NoOpEventUpcaster();
+
+        $upcasterChain = new UpcasterChain(
+            $upcasterOne->reveal(),
+            $upcasterTwo->reveal(),
+            $upcasterThree->reveal(),
+            $upcasterFour
+        );
+
+        $messages = $upcasterChain->upcast($initialMessage);
+
+        $expectedMessagePayloads = [
+            ['name' => 'initialMessage'],
+            ['name' => 'subsequentMessage-modified'],
+            ['name' => 'furtherSubsequentMessage'],
+        ];
+        $messagePayloads = array_map(function (Message $message) {
+            return $message->payload();
+        }, $messages);
+
+        $this->assertEquals($expectedMessagePayloads, $messagePayloads);
     }
 
     protected function createUpcasterWhoCanUpcast(): SingleEventUpcaster

--- a/tests/Upcasting/UpcasterChainTest.php
+++ b/tests/Upcasting/UpcasterChainTest.php
@@ -104,7 +104,7 @@ class UpcasterChainTest extends TestCase
             ['name' => 'subsequentMessage-modified'],
             ['name' => 'furtherSubsequentMessage'],
         ];
-        $messagePayloads = array_map(function (Message $message) {
+        $messagePayloads = \array_map(function (Message $message) {
             return $message->payload();
         }, $messages);
 

--- a/tests/Upcasting/UpcasterChainTest.php
+++ b/tests/Upcasting/UpcasterChainTest.php
@@ -19,7 +19,6 @@ use Prooph\EventStore\Upcasting\NoOpEventUpcaster;
 use Prooph\EventStore\Upcasting\SingleEventUpcaster;
 use Prooph\EventStore\Upcasting\Upcaster;
 use Prooph\EventStore\Upcasting\UpcasterChain;
-use Prophecy\Argument;
 
 class UpcasterChainTest extends TestCase
 {


### PR DESCRIPTION
I believe there is an issue with the `UpcasterChain` where subsequent messages raised by an upcaster are removed when calling further upcasters. I've committed an initial failing test to demonstrate the issue and another commit with a fix.

I'm not sure whether the failing test matches the intended behaviour of the `UpcasterChain`. It's what my team and I expect but the maintainers of this project may have another explanation?