### PR TITLE
Make Guid class compatible with ramsey uuid 3+4

### DIFF
--- a/src/Util/Guid.php
+++ b/src/Util/Guid.php
@@ -33,7 +33,9 @@ class Guid
 
     public static function generateAsHex(): string
     {
-        return self::generate()->getHex();
+        // string cast is a BC layer for ramsey/uuid v3
+        // to be refactor when dropping retrocompatibility
+        return (string) self::generate()->getHex();
     }
 
     public static function fromString(string $uuid): UuidInterface


### PR DESCRIPTION
Problem: the composer.json was updated so it's possible to have
gedmo/uuid 4, besides the project is not compatible with it.

Solution: update Guid class.