### PR TITLE
Order messages in consideration of provided stream order

### DIFF
--- a/src/StreamIterator/MergedStreamIterator.php
+++ b/src/StreamIterator/MergedStreamIterator.php
@@ -27,6 +27,11 @@ class MergedStreamIterator implements StreamIterator
      */
     private $numberOfIterators;
 
+    /**
+     * @var array
+     */
+    private $originalIteratorOrder;
+
     public function __construct(array $streamNames, StreamIterator ...$iterators)
     {
         foreach ($iterators as $key => $iterator) {
@@ -34,6 +39,7 @@ class MergedStreamIterator implements StreamIterator
             $this->iterators[$key][1] = $streamNames[$key];
         }
         $this->numberOfIterators = \count($this->iterators);
+        $this->originalIteratorOrder = $this->iterators;
 
         $this->prioritizeIterators();
     }
@@ -100,6 +106,8 @@ class MergedStreamIterator implements StreamIterator
     private function prioritizeIterators(): void
     {
         if ($this->numberOfIterators > 1) {
+            $this->iterators = $this->originalIteratorOrder;
+
             $this->timSort($this->iterators, $this->numberOfIterators);
         }
     }

--- a/tests/StreamIterator/MergedStreamIteratorTest.php
+++ b/tests/StreamIterator/MergedStreamIteratorTest.php
@@ -170,6 +170,33 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
     /**
      * @test
      */
+    public function it_returns_messages_in_order_in_consideration_of_provided_stream_order(): void
+    {
+        $streams = [
+            'streamA' => new InMemoryStreamIterator([
+                1 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 0, 'expected_position' => 1, 'expected_stream_name' => 'streamA'], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2018-02-26T17:29:45.000000')),
+                2 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 2, 'expected_position' => 2, 'expected_stream_name' => 'streamA'], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2018-02-26T20:28:25.000000')),
+            ]),
+            'streamB' => new InMemoryStreamIterator([
+                1 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 1, 'expected_position' => 1, 'expected_stream_name' => 'streamB'], 1, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2018-02-26T17:29:45.000000')),
+                2 => TestDomainEvent::withPayloadAndSpecifiedCreatedAt(['expected_index' => 3, 'expected_position' => 2, 'expected_stream_name' => 'streamB'], 2, DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', '2018-02-26T20:28:25.000000')),
+            ]),
+        ];
+
+        $iterator = new MergedStreamIterator(\array_keys($streams), ...\array_values($streams));
+
+        $index = 0;
+        foreach ($iterator as $position => $message) {
+            $this->assertEquals($index, $message->payload()['expected_index']);
+            $this->assertEquals($iterator->streamName(), $message->payload()['expected_stream_name']);
+
+            $index++;
+        }
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_correct_stream_name(): void
     {
         $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));


### PR DESCRIPTION
This affects also version 7.5.7. /cc @basz 

This ensures that on each iteration it will start with the original stream order. This is needed if consecutive dates are equal. See test case.