### PR TITLE
[7.x] Add PHP8 to travis / PHP8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 nbproject
 composer.lock
 docs/html
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,12 @@ matrix:
     - php: 7.4
       env:
         - DEPENDENCIES="--prefer-lowest --prefer-stable"
+    - php: 8.0
+      env:
+        - DEPENDENCIES=""
+    - php: 8.0
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_script:
   - phpenv config-rm xdebug.ini
   - composer self-update
   - composer update --prefer-dist $DEPENDENCIES
-  - rm -rf .php_cs.cache
+  - rm -rf $HOME/.php-cs-fixer/.php_cs.cache
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; elif [[ $PHP_CS == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run; else ./vendor/bin/phpunit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ matrix:
     - php: 7.4
       env:
         - DEPENDENCIES="--prefer-lowest --prefer-stable"
-    - php: 8.0.0
+    - php: 8.0
       env:
         - DEPENDENCIES=""
-    - php: 8.0.0
+    - php: 8.0
       env:
         - DEPENDENCIES="--prefer-lowest --prefer-stable"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_script:
   - phpenv config-rm xdebug.ini
   - composer self-update
   - composer update --prefer-dist $DEPENDENCIES
+  - rm -rf .php_cs.cache
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; elif [[ $PHP_CS == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run; else ./vendor/bin/phpunit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,15 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPENDENCIES=""
-        - EXECUTE_CS_CHECK=true
+        - XDEBUG_MODE="coverage"
         - TEST_COVERAGE=true
-    - php: 7.1
-      env:
-        - DEPENDENCIES="--prefer-lowest --prefer-stable"
-    - php: 7.2
+    - php: 7.3
       env:
         - DEPENDENCIES=""
-    - php: 7.2
-      env:
-        - DEPENDENCIES="--prefer-lowest --prefer-stable"
+        - PHP_CS=true
     - php: 7.3
       env:
         - DEPENDENCIES=""
@@ -49,8 +44,7 @@ before_script:
   - composer update --prefer-dist $DEPENDENCIES
 
 script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; else ./vendor/bin/phpunit; fi
-  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; elif [[ $PHP_CS == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run; else ./vendor/bin/phpunit; fi
 
 after_success:
   - if [[ $TEST_COVERAGE == 'true' ]]; then php vendor/bin/coveralls -v; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ matrix:
     - php: 7.4
       env:
         - DEPENDENCIES="--prefer-lowest --prefer-stable"
-    - php: 8.0
+    - php: 8.0.0
       env:
         - DEPENDENCIES=""
-    - php: 8.0
+    - php: 8.0.0
       env:
         - DEPENDENCIES="--prefer-lowest --prefer-stable"
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ To establish a consistent code quality, please provide unit tests for all your c
 |---------|------------|---------------|---------------|
 | 5.x     | EOL        | \>= 5.5        | EOL           |
 | 6.x     | Maintained | \>= 5.5        | 3 Dec 2017    |
-| 7.x     | Latest     | \>= 7.1 \| 8.0  | active        |
+| 7.5.x   | Latest     | \>= 7.         | active        |
+| 7.6     | Latest     | \>= 7.3 \| 8.0  | active        |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 PHP 7.1 EventStore Implementation.
 
-[![Build Status](https://travis-ci.org/prooph/event-store.svg?branch=master)](https://travis-ci.org/prooph/event-store)
-[![Coverage Status](https://coveralls.io/repos/prooph/event-store/badge.svg?branch=master&service=github)](https://coveralls.io/github/prooph/event-store?branch=master)
+[![Build Status](https://travis-ci.com/prooph/event-store.svg?branch=7.x)](https://travis-ci.com/prooph/event-store)
+[![Coverage Status](https://coveralls.io/repos/prooph/event-store/badge.svg?branch=7.x&service=github)](https://coveralls.io/github/prooph/event-store?branch=7.x)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/prooph/improoph)
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ To establish a consistent code quality, please provide unit tests for all your c
 
 ## Version Guidance
 
-| Version | Status     | PHP Version | Support Until |
-|---------|------------|-------------|---------------|
-| 5.x     | EOL        | >= 5.5      | EOL           |
-| 6.x     | Maintained | >= 5.5      | 3 Dec 2017    |
-| 7.x     | Latest     | >= 7.1      | active        |
+| Version | Status     | PHP Version   | Support Until |
+|---------|------------|---------------|---------------|
+| 5.x     | EOL        | \>= 5.5        | EOL           |
+| 6.x     | Maintained | \>= 5.5        | 3 Dec 2017    |
+| 7.x     | Latest     | \>= 7.1 \| 8.0  | active        |
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.1 ||  8.0",
+        "php": "^7.1 || ^8.0",
         "marc-mabe/php-enum": "^2.3.1 || ^3.0.0 || ^4.0.0",
         "prooph/common": "^4.1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 ||  8.0",
         "marc-mabe/php-enum": "^2.3.1 || ^3.0.0 || ^4.0.0",
         "prooph/common": "^4.1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,15 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "marc-mabe/php-enum": "^2.3.1 || ^3.0.0 || ^4.0.0",
-        "prooph/common": "^4.1.0"
+        "prooph/common": "^4.5.0"
     },
     "require-dev": {
         "phpspec/prophecy": "^1.10.3",
-        "phpunit/php-invoker": "^2.0",
-        "phpunit/phpunit": "^7.5.20",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/php-invoker": "^3.1",
+        "phpunit/phpunit": "^9.0",
         "prooph/bookdown-template": "^0.2.3",
-        "prooph/php-cs-fixer-config": "v0.3.1",
+        "prooph/php-cs-fixer-config": "^0.4",
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^2.0.1",
         "satooshi/php-coveralls": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpspec/prophecy": "^1.10.3",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/php-invoker": "^3.1",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^9.3",
         "prooph/bookdown-template": "^0.2.3",
         "prooph/php-cs-fixer-config": "^0.4",
         "psr/container": "^1.0",

--- a/examples/event/QuickStartSucceeded.php
+++ b/examples/event/QuickStartSucceeded.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/examples/quickstart.php
+++ b/examples/quickstart.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,9 +18,9 @@
         <directory>./tests</directory>
     </testsuite>
 
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
          enforceTimeLimit="true"
          failOnWarning="true"
          failOnRisky="true"
+         timeoutForLargeTests="180"
 >
     <testsuite name="Prooph EventStore Test Suite">
         <directory>./tests</directory>

--- a/src/ActionEventEmitterEventStore.php
+++ b/src/ActionEventEmitterEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/InMemoryEventStoreFactory.php
+++ b/src/Container/InMemoryEventStoreFactory.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/InMemoryProjectionManagerFactory.php
+++ b/src/Container/InMemoryProjectionManagerFactory.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/EventStore.php
+++ b/src/EventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/EventStoreDecorator.php
+++ b/src/EventStoreDecorator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ConcurrencyException.php
+++ b/src/Exception/ConcurrencyException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/EventStoreException.php
+++ b/src/Exception/EventStoreException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ExtensionNotLoadedException.php
+++ b/src/Exception/ExtensionNotLoadedException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/OutOfRangeException.php
+++ b/src/Exception/OutOfRangeException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ProjectionNotFound.php
+++ b/src/Exception/ProjectionNotFound.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/StreamExistsAlready.php
+++ b/src/Exception/StreamExistsAlready.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/StreamNotFound.php
+++ b/src/Exception/StreamNotFound.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/TransactionAlreadyStarted.php
+++ b/src/Exception/TransactionAlreadyStarted.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/TransactionNotStarted.php
+++ b/src/Exception/TransactionNotStarted.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/InMemoryEventStore.php
+++ b/src/InMemoryEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/FieldType.php
+++ b/src/Metadata/FieldType.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/MetadataEnricher.php
+++ b/src/Metadata/MetadataEnricher.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/MetadataEnricherAggregate.php
+++ b/src/Metadata/MetadataEnricherAggregate.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/MetadataEnricherPlugin.php
+++ b/src/Metadata/MetadataEnricherPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/MetadataMatcher.php
+++ b/src/Metadata/MetadataMatcher.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/Operator.php
+++ b/src/Metadata/Operator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/NonTransactionalInMemoryEventStore.php
+++ b/src/NonTransactionalInMemoryEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Plugin/AbstractPlugin.php
+++ b/src/Plugin/AbstractPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Plugin/UpcastingPlugin.php
+++ b/src/Plugin/UpcastingPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/AbstractReadModel.php
+++ b/src/Projection/AbstractReadModel.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/InMemoryEventStoreProjector.php
+++ b/src/Projection/InMemoryEventStoreProjector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/InMemoryEventStoreQuery.php
+++ b/src/Projection/InMemoryEventStoreQuery.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/InMemoryEventStoreReadModelProjector.php
+++ b/src/Projection/InMemoryEventStoreReadModelProjector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/InMemoryProjectionManager.php
+++ b/src/Projection/InMemoryProjectionManager.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/ProjectionManager.php
+++ b/src/Projection/ProjectionManager.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/ProjectionStatus.php
+++ b/src/Projection/ProjectionStatus.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/Projector.php
+++ b/src/Projection/Projector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/Query.php
+++ b/src/Projection/Query.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/ReadModel.php
+++ b/src/Projection/ReadModel.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/ReadModelProjector.php
+++ b/src/Projection/ReadModelProjector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/ReadOnlyEventStore.php
+++ b/src/ReadOnlyEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/ReadOnlyEventStoreWrapper.php
+++ b/src/ReadOnlyEventStoreWrapper.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/EmptyStreamIterator.php
+++ b/src/StreamIterator/EmptyStreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/InMemoryStreamIterator.php
+++ b/src/StreamIterator/InMemoryStreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/MergedStreamIterator.php
+++ b/src/StreamIterator/MergedStreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/StreamIterator.php
+++ b/src/StreamIterator/StreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/TimSort.php
+++ b/src/StreamIterator/TimSort.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamName.php
+++ b/src/StreamName.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/TransactionalActionEventEmitterEventStore.php
+++ b/src/TransactionalActionEventEmitterEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/TransactionalEventStore.php
+++ b/src/TransactionalEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/NoOpEventUpcaster.php
+++ b/src/Upcasting/NoOpEventUpcaster.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/SingleEventUpcaster.php
+++ b/src/Upcasting/SingleEventUpcaster.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/Upcaster.php
+++ b/src/Upcasting/Upcaster.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/UpcasterChain.php
+++ b/src/Upcasting/UpcasterChain.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/UpcastingIterator.php
+++ b/src/Upcasting/UpcastingIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Util/ArrayCache.php
+++ b/src/Util/ArrayCache.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Util/Assertion.php
+++ b/src/Util/Assertion.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/AbstractEventStoreTest.php
+++ b/tests/AbstractEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/AbstractEventStoreTest.php
+++ b/tests/AbstractEventStoreTest.php
@@ -28,13 +28,15 @@ use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\TestDomainEvent;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Common tests for all event store implementations
  */
 abstract class AbstractEventStoreTest extends TestCase
 {
-    use EventStoreTestStreamTrait;
+    use EventStoreTestStreamTrait,
+        ProphecyTrait;
 
     /**
      * @var EventStore

--- a/tests/ActionEventEmitterEventStoreTest.php
+++ b/tests/ActionEventEmitterEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ProophTest\EventStore;
 
 use ArrayIterator;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\ProophActionEventEmitter;
 use Prooph\EventStore\ActionEventEmitterEventStore;
@@ -26,6 +25,7 @@ use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\UsernameChanged;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestCase
 {

--- a/tests/ActionEventEmitterEventStoreTest.php
+++ b/tests/ActionEventEmitterEventStoreTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore;
 
 use ArrayIterator;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\ProophActionEventEmitter;
 use Prooph\EventStore\ActionEventEmitterEventStore;
@@ -28,7 +29,8 @@ use ProophTest\EventStore\Mock\UsernameChanged;
 
 class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestCase
 {
-    use EventStoreTestStreamTrait;
+    use EventStoreTestStreamTrait,
+        ProphecyTrait;
 
     /**
      * @test

--- a/tests/ActionEventEmitterEventStoreTestCase.php
+++ b/tests/ActionEventEmitterEventStoreTestCase.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/InMemoryEventStoreFactoryTest.php
+++ b/tests/Container/InMemoryEventStoreFactoryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/InMemoryEventStoreFactoryTest.php
+++ b/tests/Container/InMemoryEventStoreFactoryTest.php
@@ -31,10 +31,13 @@ use Prooph\EventStore\TransactionalActionEventEmitterEventStore;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class InMemoryEventStoreFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/Container/InMemoryEventStoreFactoryTest.php
+++ b/tests/Container/InMemoryEventStoreFactoryTest.php
@@ -46,7 +46,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['default'] = [];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -62,7 +62,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['default'] = ['wrap_action_event_emitter' => false];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -78,7 +78,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['default'] = ['wrap_action_event_emitter' => false, 'transactional' => false];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -94,7 +94,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['default'] = ['wrap_action_event_emitter' => false, 'read_only' => true];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -110,7 +110,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['another'] = [];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->method('get')->with('config')->willReturn($config);
 
         $type = 'another';
         $eventStore = InMemoryEventStoreFactory::$type($containerMock);
@@ -126,7 +126,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['another'] = ['transactional' => false];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->method('get')->with('config')->willReturn($config);
 
         $type = 'another';
         $eventStore = InMemoryEventStoreFactory::$type($containerMock);
@@ -144,8 +144,9 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $eventEmitterMock = $this->getMockForAbstractClass(ActionEventEmitter::class);
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
-        $containerMock->expects($this->at(1))->method('get')->with('event_emitter')->willReturn($eventEmitterMock);
+        $containerMock->method('get')
+            ->withConsecutive(['config'], ['event_emitter'])
+            ->willReturnOnConsecutiveCalls($config, $eventEmitterMock);
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -164,8 +165,9 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $featureMock->attachToEventStore(Argument::type(TransactionalActionEventEmitterEventStore::class))->shouldBeCalled();
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
-        $containerMock->expects($this->at(1))->method('get')->with('plugin')->willReturn($featureMock->reveal());
+        $containerMock->method('get')
+            ->withConsecutive(['config'], ['plugin'])
+            ->willReturnOnConsecutiveCalls($config, $featureMock->reveal());
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -186,8 +188,9 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $featureMock = 'foo';
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
-        $containerMock->expects($this->at(1))->method('get')->with('plugin')->willReturn($featureMock);
+        $containerMock->method('get')
+            ->withConsecutive(['config'], ['plugin'])
+            ->willReturnOnConsecutiveCalls($config, $featureMock);
 
         $factory = new InMemoryEventStoreFactory();
         $factory($containerMock);

--- a/tests/Container/InMemoryProjectionManagerFactoryTest.php
+++ b/tests/Container/InMemoryProjectionManagerFactoryTest.php
@@ -18,10 +18,13 @@ use Prooph\EventStore\Container\InMemoryProjectionManagerFactory;
 use Prooph\EventStore\Exception\InvalidArgumentException;
 use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class InMemoryProjectionManagerFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/Container/InMemoryProjectionManagerFactoryTest.php
+++ b/tests/Container/InMemoryProjectionManagerFactoryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/EventStoreTestStreamTrait.php
+++ b/tests/EventStoreTestStreamTrait.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Example/QuickStartTest.php
+++ b/tests/Example/QuickStartTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Example/QuickStartTest.php
+++ b/tests/Example/QuickStartTest.php
@@ -27,7 +27,7 @@ class QuickStartTest extends TestCase
             '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
         );
 
-        $this->assertRegExp($pattern, $this->getQuickstartOutput());
+        $this->assertMatchesRegularExpression($pattern, $this->getQuickstartOutput());
     }
 
     private function getQuickstartOutput(): string

--- a/tests/InMemoryEventStoreTest.php
+++ b/tests/InMemoryEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Metadata/MetadataEnricherAggregateTest.php
+++ b/tests/Metadata/MetadataEnricherAggregateTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Metadata/MetadataEnricherAggregateTest.php
+++ b/tests/Metadata/MetadataEnricherAggregateTest.php
@@ -20,9 +20,12 @@ use Prooph\EventStore\Metadata\MetadataEnricher;
 use Prooph\EventStore\Metadata\MetadataEnricherAggregate;
 use ProophTest\EventStore\Mock\TestDomainEvent;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class MetadataEnricherAggregateTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/Metadata/MetadataEnricherPluginTest.php
+++ b/tests/Metadata/MetadataEnricherPluginTest.php
@@ -25,9 +25,12 @@ use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\TestDomainEvent;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class MetadataEnricherPluginTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/Metadata/MetadataEnricherPluginTest.php
+++ b/tests/Metadata/MetadataEnricherPluginTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Metadata/MetadataMatcherTest.php
+++ b/tests/Metadata/MetadataMatcherTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/EventLoggerPlugin.php
+++ b/tests/Mock/EventLoggerPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/Post.php
+++ b/tests/Mock/Post.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/PostCreated.php
+++ b/tests/Mock/PostCreated.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/Product.php
+++ b/tests/Mock/Product.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/ReadModelMock.php
+++ b/tests/Mock/ReadModelMock.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/TestDomainEvent.php
+++ b/tests/Mock/TestDomainEvent.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/TestIteratorAggregate.php
+++ b/tests/Mock/TestIteratorAggregate.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/User.php
+++ b/tests/Mock/User.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/UserCreated.php
+++ b/tests/Mock/UserCreated.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/UsernameChanged.php
+++ b/tests/Mock/UsernameChanged.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/NonTransactionalInMemoryEventStoreTest.php
+++ b/tests/NonTransactionalInMemoryEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Plugin/PluginManagerTest.php
+++ b/tests/Plugin/PluginManagerTest.php
@@ -18,10 +18,13 @@ use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\ActionEventEmitterEventStoreTestCase;
 use ProophTest\EventStore\Mock\EventLoggerPlugin;
 use ProophTest\EventStore\Mock\UserCreated;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class PluginManagerTest extends ActionEventEmitterEventStoreTestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/Plugin/PluginManagerTest.php
+++ b/tests/Plugin/PluginManagerTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Plugin/UpcastingPluginTest.php
+++ b/tests/Plugin/UpcastingPluginTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractEventStoreProjectorTest.php
+++ b/tests/Projection/AbstractEventStoreProjectorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractEventStoreProjectorTest.php
+++ b/tests/Projection/AbstractEventStoreProjectorTest.php
@@ -777,13 +777,13 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
 
         $state = $projection->getState();
 
-        $this->assertInternalType('array', $state);
+        $this->assertIsArray($state);
 
         $projection->reset();
 
         $state2 = $projection->getState();
 
-        $this->assertInternalType('array', $state2);
+        $this->assertIsArray($state2);
     }
 
     /**

--- a/tests/Projection/AbstractEventStoreQueryTest.php
+++ b/tests/Projection/AbstractEventStoreQueryTest.php
@@ -300,13 +300,13 @@ abstract class AbstractEventStoreQueryTest extends TestCase
 
         $state = $query->getState();
 
-        $this->assertInternalType('array', $state);
+        $this->assertIsArray($state);
 
         $query->reset();
 
         $state2 = $query->getState();
 
-        $this->assertInternalType('array', $state2);
+        $this->assertIsArray($state2);
     }
 
     /**

--- a/tests/Projection/AbstractEventStoreQueryTest.php
+++ b/tests/Projection/AbstractEventStoreQueryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/AbstractEventStoreReadModelProjectorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/AbstractEventStoreReadModelProjectorTest.php
@@ -29,12 +29,15 @@ use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\ReadModelMock;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Common tests for all event store read model projector implementations
  */
 abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ProjectionManager
      */
@@ -418,13 +421,13 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
 
         $state = $projection->getState();
 
-        $this->assertInternalType('array', $state);
+        $this->assertIsArray($state);
 
         $projection->reset();
 
         $state2 = $projection->getState();
 
-        $this->assertInternalType('array', $state2);
+        $this->assertIsArray($state2);
     }
 
     /**

--- a/tests/Projection/AbstractProjectionManagerTest.php
+++ b/tests/Projection/AbstractProjectionManagerTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractProjectionManagerTest.php
+++ b/tests/Projection/AbstractProjectionManagerTest.php
@@ -32,6 +32,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
 
     /**
      * @test
+     * @medium
      */
     public function it_fetches_projection_names(): void
     {
@@ -157,6 +158,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
 
     /**
      * @test
+     * @medium
      */
     public function it_fetches_projection_names_using_regex(): void
     {

--- a/tests/Projection/InMemoryEventStoreProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryEventStoreProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectorTest.php
@@ -20,9 +20,12 @@ use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\NonTransactionalInMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryEventStoreProjector;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
 {
+    use ProphecyTrait;
+
     /**
      * @var InMemoryProjectionManager
      */
@@ -178,6 +181,7 @@ class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
 
     /**
      * @test
+     * @medium
      */
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {

--- a/tests/Projection/InMemoryEventStoreQueryTest.php
+++ b/tests/Projection/InMemoryEventStoreQueryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryEventStoreQueryTest.php
+++ b/tests/Projection/InMemoryEventStoreQueryTest.php
@@ -20,9 +20,12 @@ use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\NonTransactionalInMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryEventStoreQuery;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class InMemoryEventStoreQueryTest extends AbstractEventStoreQueryTest
 {
+    use ProphecyTrait;
+
     /**
      * @var InMemoryProjectionManager
      */

--- a/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
@@ -189,6 +189,7 @@ class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadMod
 
     /**
      * @test
+     * @medium
      */
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {

--- a/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryProjectionManagerTest.php
+++ b/tests/Projection/InMemoryProjectionManagerTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryProjectionManagerTest.php
+++ b/tests/Projection/InMemoryProjectionManagerTest.php
@@ -20,15 +20,18 @@ use Prooph\EventStore\Exception\RuntimeException;
 use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\NonTransactionalInMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class InMemoryProjectionManagerTest extends AbstractProjectionManagerTest
 {
+    use ProphecyTrait;
+
     /**
      * @var InMemoryProjectionManager
      */
     protected $projectionManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->projectionManager = new InMemoryProjectionManager(new InMemoryEventStore());
     }

--- a/tests/Projection/isolated-long-running-projection.php
+++ b/tests/Projection/isolated-long-running-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/isolated-long-running-query.php
+++ b/tests/Projection/isolated-long-running-query.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/isolated-long-running-read-model-projection.php
+++ b/tests/Projection/isolated-long-running-read-model-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/isolated-projection.php
+++ b/tests/Projection/isolated-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/isolated-read-model-projection.php
+++ b/tests/Projection/isolated-read-model-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/ReadOnlyEventStoreWrapperTest.php
+++ b/tests/ReadOnlyEventStoreWrapperTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/ReadOnlyEventStoreWrapperTest.php
+++ b/tests/ReadOnlyEventStoreWrapperTest.php
@@ -18,9 +18,12 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\ReadOnlyEventStoreWrapper;
 use Prooph\EventStore\StreamName;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ReadOnlyEventStoreWrapperTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/StreamIterator/AbstractStreamIteratorTest.php
+++ b/tests/StreamIterator/AbstractStreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/EmptyStreamIteratorTest.php
+++ b/tests/StreamIterator/EmptyStreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/InMemoryStreamIteratorTest.php
+++ b/tests/StreamIterator/InMemoryStreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/MergedStreamIteratorTest.php
+++ b/tests/StreamIterator/MergedStreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/MergedStreamIteratorTest.php
+++ b/tests/StreamIterator/MergedStreamIteratorTest.php
@@ -152,6 +152,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
 
     /**
      * @test
+     * @large
      */
     public function it_returns_messages_in_order_for_large_streams(): void
     {

--- a/tests/StreamNameTest.php
+++ b/tests/StreamNameTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/TransactionalActionEventEmitterEventStoreTest.php
+++ b/tests/TransactionalActionEventEmitterEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/TransactionalActionEventEmitterEventStoreTest.php
+++ b/tests/TransactionalActionEventEmitterEventStoreTest.php
@@ -21,10 +21,12 @@ use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use Prooph\EventStore\TransactionalActionEventEmitterEventStore;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class TransactionalActionEventEmitterEventStoreTest extends TestCase
 {
-    use EventStoreTestStreamTrait;
+    use EventStoreTestStreamTrait,
+        ProphecyTrait;
 
     /**
      * @var TransactionalActionEventEmitterEventStore

--- a/tests/TransactionalEventStoreTestTrait.php
+++ b/tests/TransactionalEventStoreTestTrait.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/TransactionalEventStoreTestTrait.php
+++ b/tests/TransactionalEventStoreTestTrait.php
@@ -22,12 +22,15 @@ use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use Prooph\EventStore\TransactionalEventStore;
 use ProophTest\EventStore\Mock\UsernameChanged;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Common tests for all transactional event store implementations
  */
 trait TransactionalEventStoreTestTrait
 {
+    use ProphecyTrait;
+
     /**
      * @var TransactionalEventStore
      */

--- a/tests/Upcasting/NoOpEventUpcasterTest.php
+++ b/tests/Upcasting/NoOpEventUpcasterTest.php
@@ -16,9 +16,12 @@ namespace ProophTest\EventStore\Upcasting;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\Upcasting\NoOpEventUpcaster;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class NoOpEventUpcasterTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -30,7 +33,7 @@ class NoOpEventUpcasterTest extends TestCase
         $upcaster = new NoOpEventUpcaster();
 
         $messages = $upcaster->upcast($message);
-        $this->assertInternalType('array', $messages);
+        $this->assertIsArray($messages);
         $this->assertNotEmpty($messages);
         $this->assertSame($message, $messages[0]);
     }

--- a/tests/Upcasting/NoOpEventUpcasterTest.php
+++ b/tests/Upcasting/NoOpEventUpcasterTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Upcasting/SingleEventUpcasterTest.php
+++ b/tests/Upcasting/SingleEventUpcasterTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Upcasting/SingleEventUpcasterTest.php
+++ b/tests/Upcasting/SingleEventUpcasterTest.php
@@ -16,9 +16,12 @@ namespace ProophTest\EventStore\Upcasting;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\Upcasting\SingleEventUpcaster;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class SingleEventUpcasterTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -35,7 +38,7 @@ class SingleEventUpcasterTest extends TestCase
 
         $messages = $upcaster->upcast($message);
 
-        $this->assertInternalType('array', $messages);
+        $this->assertIsArray($messages);
         $this->assertNotEmpty($messages);
         $this->assertSame($upcastedMessage, $messages[0]);
     }
@@ -53,7 +56,7 @@ class SingleEventUpcasterTest extends TestCase
 
         $messages = $upcaster->upcast($message);
 
-        $this->assertInternalType('array', $messages);
+        $this->assertIsArray($messages);
         $this->assertNotEmpty($messages);
         $this->assertSame($message, $messages[0]);
     }

--- a/tests/Upcasting/UpcasterChainTest.php
+++ b/tests/Upcasting/UpcasterChainTest.php
@@ -19,9 +19,12 @@ use Prooph\EventStore\Upcasting\NoOpEventUpcaster;
 use Prooph\EventStore\Upcasting\SingleEventUpcaster;
 use Prooph\EventStore\Upcasting\Upcaster;
 use Prooph\EventStore\Upcasting\UpcasterChain;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class UpcasterChainTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -50,7 +53,7 @@ class UpcasterChainTest extends TestCase
 
         $messages = $upcasterChain->upcast($message);
 
-        $this->assertInternalType('array', $messages);
+        $this->assertIsArray($messages);
         $this->assertNotEmpty($messages);
         $this->assertSame($upcastedMessage2, $messages[0]);
         $this->assertSame($upcastedMessage3, $messages[1]);

--- a/tests/Upcasting/UpcasterChainTest.php
+++ b/tests/Upcasting/UpcasterChainTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Upcasting/UpcastingIteratorTest.php
+++ b/tests/Upcasting/UpcastingIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Upcasting/UpcastingIteratorTest.php
+++ b/tests/Upcasting/UpcastingIteratorTest.php
@@ -20,9 +20,12 @@ use Prooph\EventStore\StreamIterator\InMemoryStreamIterator;
 use Prooph\EventStore\StreamIterator\StreamIterator;
 use Prooph\EventStore\Upcasting\SingleEventUpcaster;
 use Prooph\EventStore\Upcasting\UpcastingIterator;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class UpcastingIteratorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/Util/ArrayCacheTest.php
+++ b/tests/Util/ArrayCacheTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2020 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
- ~~Travis is currently missing the PHP 8 option ( https://travis-ci.community/t/php-8-0-missing/10132/17 ) but should be available next week~~
- This is mostly to see if/what needs to change to PHP8 support

Changes:
- [x] Updated the README badges to link to the correct branch for this version
- [x] Use `ProphesizeTrait`, `prophesize` integration has been [moved](https://github.com/sebastianbergmann/phpunit/issues/4141)  into its own package [`phpspec/prophecy-phpunit`](https://github.com/phpspec/prophecy-phpunit)
- [x] Replaced calls to `assertInternalType()` with new assertions ( old ones have been [removed](https://github.com/sebastianbergmann/phpunit/issues/3368) )
- [x] [`assertRegExp`](https://github.com/sebastianbergmann/phpunit/issues/4086) is deprecated and replaced 
- [x] Annotated a few tests with `@medium`  that were running longer than 1 second and thus being stopped
- [x] Update travis
- [x] Fix `at` deprecation warnings in phpunit
- [x] Update Doc-Header for 2021