### PR TITLE
Fix issue 414, add tests + add php8 to travis (but not composer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build
 .idea
 .php_cs.cache
+.phpunit.result.cache
 nbproject
 composer.lock
 docs/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ matrix:
     - DEPENDENCIES="--prefer-lowest --prefer-stable"
   - php: 8.0
     env:
-    - DEPENDENCIES="--ignore-platform-reqs"
+    - DEPENDENCIES="--ignore-platform-req=php"
   - php: 8.0
     env:
-    - DEPENDENCIES="--ignore-platform-reqs --prefer-lowest --prefer-stable"
+    - DEPENDENCIES="--ignore-platform-req=php --prefer-lowest --prefer-stable"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ matrix:
   - php: 7.4
     env:
     - DEPENDENCIES="--prefer-lowest --prefer-stable"
+  - php: 8.0
+    env:
+    - DEPENDENCIES="--ignore-platform-reqs"
+  - php: 8.0
+    env:
+    - DEPENDENCIES="--ignore-platform-reqs --prefer-lowest --prefer-stable"
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php-coveralls/php-coveralls": "^2.2",
     "phpspec/prophecy": "^1.10.3",
     "phpunit/phpunit": "^9.1",
-    "prooph/php-cs-fixer-config": "^0.3.1",
+    "prooph/php-cs-fixer-config": "^0.4.0",
     "vimeo/psalm": "^3.11.2,<3.12"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "prefer-stable": true,
   "require": {
-    "php": "^7.4",
+    "php": "^7.4||^8.0",
     "ext-json": "*",
     "ramsey/uuid": "^3.9.3"
   },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "prefer-stable": true,
   "require": {
-    "php": "^7.4||^8.0",
+    "php": "^7.4",
     "ext-json": "*",
     "ramsey/uuid": "^3.9.3"
   },
@@ -28,7 +28,7 @@
     "phpspec/prophecy": "^1.10.3",
     "phpunit/phpunit": "^9.1",
     "prooph/php-cs-fixer-config": "^0.3.1",
-    "vimeo/psalm": "^3.11.2"
+    "vimeo/psalm": "^3.11.2,<3.12"
   },
   "autoload": {
     "psr-4": {

--- a/src/Internal/DateTimeStringBugWorkaround.php
+++ b/src/Internal/DateTimeStringBugWorkaround.php
@@ -23,7 +23,6 @@ final class DateTimeStringBugWorkaround
     {
         $micros = \substr($dateTimeString, 20, -1);
 
-        // PHP versions before v8 returned false instead of an empty string
         if (false === $micros || '' === $micros) {
             // no microseconds given
             $dateTimeString = \substr($dateTimeString, 0, 19) . '.';

--- a/src/Internal/DateTimeStringBugWorkaround.php
+++ b/src/Internal/DateTimeStringBugWorkaround.php
@@ -23,7 +23,8 @@ final class DateTimeStringBugWorkaround
     {
         $micros = \substr($dateTimeString, 20, -1);
 
-        if (false === $micros) {
+        // PHP versions before v8 returned false instead of an empty string
+        if (false === $micros || '' === $micros) {
             // no microseconds given
             $dateTimeString = \substr($dateTimeString, 0, 19) . '.';
             $micros = '';

--- a/tests/Internal/DateTimeStringBugWorkaroundTest.php
+++ b/tests/Internal/DateTimeStringBugWorkaroundTest.php
@@ -1,8 +1,17 @@
 <?php
 
+/**
+ * This file is part of prooph/event-store.
+ * (c) 2014-2020 Alexander Miertsch <kontakt@codeliner.ws>
+ * (c) 2015-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
 
 namespace ProophTest\EventStore\Internal;
-
 
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Internal\DateTimeStringBugWorkaround;
@@ -14,15 +23,15 @@ class DateTimeStringBugWorkaroundTest extends TestCase
         return [
             [
                 '2020-12-14T12:55:57Z',
-                '2020-12-14T12:55:57.000000Z'
+                '2020-12-14T12:55:57.000000Z',
             ],
             [
                 '2020-12-14T12:55:57.1234567Z',
-                '2020-12-14T12:55:57.123456Z'
+                '2020-12-14T12:55:57.123456Z',
             ],
             [
                 '2020-12-14T12:55:57.1234Z',
-                '2020-12-14T12:55:57.123400Z'
+                '2020-12-14T12:55:57.123400Z',
             ],
         ];
     }

--- a/tests/Internal/DateTimeStringBugWorkaroundTest.php
+++ b/tests/Internal/DateTimeStringBugWorkaroundTest.php
@@ -9,27 +9,32 @@ use Prooph\EventStore\Internal\DateTimeStringBugWorkaround;
 
 class DateTimeStringBugWorkaroundTest extends TestCase
 {
-    public function test_it_correctly_converts_datetime_with_missing_micros()
+    public function provider(): array
     {
-        $date = "2020-12-14T12:55:57Z";
-        $expectedConvertedDate = "2020-12-14T12:55:57.000000Z";
-        $convertedDate = DateTimeStringBugWorkaround::fixDateTimeString($date);
-        $this->assertEquals($convertedDate, $expectedConvertedDate);
+        return [
+            [
+                '2020-12-14T12:55:57Z',
+                '2020-12-14T12:55:57.000000Z'
+            ],
+            [
+                '2020-12-14T12:55:57.1234567Z',
+                '2020-12-14T12:55:57.123456Z'
+            ],
+            [
+                '2020-12-14T12:55:57.1234Z',
+                '2020-12-14T12:55:57.123400Z'
+            ],
+        ];
     }
 
-    public function test_it_correctly_converts_datetime_with_more_than_6_micros()
+    /**
+     * @param string $date
+     * @param string $expectedConvertedDate
+     * @dataProvider provider
+     */
+    public function test_it_correctly_converts_datetime(string $date, string $expectedConvertedDate): void
     {
-        $date = "2020-12-14T12:55:57.1234567Z";
-        $expectedConvertedDate = "2020-12-14T12:55:57.123456Z";
-        $convertedDate = DateTimeStringBugWorkaround::fixDateTimeString($date);
-        $this->assertEquals($convertedDate, $expectedConvertedDate);
-    }
-
-    public function test_it_correctly_converts_datetime_with_less_than_6_micros()
-    {
-        $date = "2020-12-14T12:55:57.1234Z";
-        $expectedConvertedDate = "2020-12-14T12:55:57.123400Z";
-        $convertedDate = DateTimeStringBugWorkaround::fixDateTimeString($date);
-        $this->assertEquals($convertedDate, $expectedConvertedDate);
+        $actualConvertedDate = DateTimeStringBugWorkaround::fixDateTimeString($date);
+        $this->assertEquals($expectedConvertedDate, $actualConvertedDate);
     }
 }

--- a/tests/Internal/DateTimeStringBugWorkaroundTest.php
+++ b/tests/Internal/DateTimeStringBugWorkaroundTest.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace ProophTest\EventStore\Internal;
+
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Internal\DateTimeStringBugWorkaround;
+
+class DateTimeStringBugWorkaroundTest extends TestCase
+{
+    public function test_it_correctly_converts_datetime_with_missing_micros()
+    {
+        $date = "2020-12-14T12:55:57Z";
+        $expectedConvertedDate = "2020-12-14T12:55:57.000000Z";
+        $convertedDate = DateTimeStringBugWorkaround::fixDateTimeString($date);
+        $this->assertEquals($convertedDate, $expectedConvertedDate);
+    }
+
+    public function test_it_correctly_converts_datetime_with_more_than_6_micros()
+    {
+        $date = "2020-12-14T12:55:57.1234567Z";
+        $expectedConvertedDate = "2020-12-14T12:55:57.123456Z";
+        $convertedDate = DateTimeStringBugWorkaround::fixDateTimeString($date);
+        $this->assertEquals($convertedDate, $expectedConvertedDate);
+    }
+
+    public function test_it_correctly_converts_datetime_with_less_than_6_micros()
+    {
+        $date = "2020-12-14T12:55:57.1234Z";
+        $expectedConvertedDate = "2020-12-14T12:55:57.123400Z";
+        $convertedDate = DateTimeStringBugWorkaround::fixDateTimeString($date);
+        $this->assertEquals($convertedDate, $expectedConvertedDate);
+    }
+}


### PR DESCRIPTION
* Fixed bug caused by php 8 no longer returning false in some cases for `substr`
* Added tests for `DateTimeStringBugWorkaround`
* Added php 8 to travis as recommended by @enumag (but not composer)

*Please go gentle on my, this is my first PR in the open source community. Please let me know if I can improve anything. I'd like to continue to contribute 😄*