### PR TITLE
PHP 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build
 .idea
 .php_cs.cache
+.phpunit.result.cache
 nbproject
 composer.lock
 docs/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,12 @@ matrix:
     - php: 7.4
       env:
         - DEPENDENCIES="--prefer-lowest --prefer-stable"
+    - php: 8.0
+      env:
+        - DEPENDENCIES=""
+    - php: 8.0
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -24,19 +24,18 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 | ^8.0",
         "marc-mabe/php-enum": "^2.3.1 || ^3.0.0 || ^4.0.0",
         "prooph/common": "^4.1.0"
     },
     "require-dev": {
-        "phpspec/prophecy": "^1.10.3",
-        "phpunit/php-invoker": "^2.0",
-        "phpunit/phpunit": "^7.5.20",
-        "prooph/bookdown-template": "^0.2.3",
-        "prooph/php-cs-fixer-config": "v0.3.1",
+        "phpspec/prophecy-phpunit": "^2.0.0",
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^2.0.1",
-        "satooshi/php-coveralls": "^1.0"
+        "phpunit/phpunit": "^9.0",
+        "prooph/php-cs-fixer-config": "^0.4",
+        "satooshi/php-coveralls": "^1.0",
+        "prooph/bookdown-template": "^0.2.3"
     },
     "suggest" : {
         "prooph/pdo-event-store": "For usage with MySQL or Postgres as event store",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="vendor/autoload.php"
-         timeoutForSmallTests="2"
-         enforceTimeLimit="true"
-         failOnWarning="true"
-         failOnRisky="true"
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="vendor/autoload.php"
+    timeoutForSmallTests="2"
+    enforceTimeLimit="true"
+    failOnWarning="true"
+    failOnRisky="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 >
-    <testsuite name="Prooph EventStore Test Suite">
-        <directory>./tests</directory>
-    </testsuite>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
+  <coverage>
+    <include>
+      <directory>./src/</directory>
+    </include>
+  </coverage>
+  <testsuite name="Prooph EventStore Test Suite">
+    <directory>./tests</directory>
+  </testsuite>
 </phpunit>

--- a/tests/AbstractEventStoreTest.php
+++ b/tests/AbstractEventStoreTest.php
@@ -28,6 +28,7 @@ use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\TestDomainEvent;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Common tests for all event store implementations
@@ -35,6 +36,7 @@ use ProophTest\EventStore\Mock\UsernameChanged;
 abstract class AbstractEventStoreTest extends TestCase
 {
     use EventStoreTestStreamTrait;
+    use ProphecyTrait;
 
     /**
      * @var EventStore

--- a/tests/ActionEventEmitterEventStoreTest.php
+++ b/tests/ActionEventEmitterEventStoreTest.php
@@ -25,9 +25,11 @@ use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\UsernameChanged;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestCase
 {
+    use ProphecyTrait;
     use EventStoreTestStreamTrait;
 
     /**

--- a/tests/Container/InMemoryEventStoreFactoryTest.php
+++ b/tests/Container/InMemoryEventStoreFactoryTest.php
@@ -32,9 +32,12 @@ use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
 use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class InMemoryEventStoreFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -43,7 +46,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['default'] = [];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->expects($this->once())->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -59,7 +62,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['default'] = ['wrap_action_event_emitter' => false];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->expects($this->once())->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -75,7 +78,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['default'] = ['wrap_action_event_emitter' => false, 'transactional' => false];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->expects($this->once())->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -91,7 +94,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['default'] = ['wrap_action_event_emitter' => false, 'read_only' => true];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->expects($this->once())->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -107,7 +110,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['another'] = [];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->expects($this->once())->method('get')->with('config')->willReturn($config);
 
         $type = 'another';
         $eventStore = InMemoryEventStoreFactory::$type($containerMock);
@@ -123,7 +126,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $config['prooph']['event_store']['another'] = ['transactional' => false];
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
+        $containerMock->expects($this->once())->method('get')->with('config')->willReturn($config);
 
         $type = 'another';
         $eventStore = InMemoryEventStoreFactory::$type($containerMock);
@@ -141,8 +144,10 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $eventEmitterMock = $this->getMockForAbstractClass(ActionEventEmitter::class);
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
-        $containerMock->expects($this->at(1))->method('get')->with('event_emitter')->willReturn($eventEmitterMock);
+        $containerMock->expects($this->any())->method('get')->willReturnMap([
+            ['config', $config],
+            ['event_emitter', $eventEmitterMock]
+        ]);
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -152,6 +157,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
 
     /**
      * @test
+     * @group only
      */
     public function it_injects_plugins(): void
     {
@@ -161,8 +167,10 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $featureMock->attachToEventStore(Argument::type(TransactionalActionEventEmitterEventStore::class))->shouldBeCalled();
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
-        $containerMock->expects($this->at(1))->method('get')->with('plugin')->willReturn($featureMock->reveal());
+        $containerMock->expects($this->any())->method('get')->willReturnMap([
+            ['config', $config],
+            ['plugin', $featureMock->reveal()]
+        ]);
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -183,8 +191,10 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $featureMock = 'foo';
 
         $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
-        $containerMock->expects($this->at(0))->method('get')->with('config')->willReturn($config);
-        $containerMock->expects($this->at(1))->method('get')->with('plugin')->willReturn($featureMock);
+        $containerMock->expects($this->any())->method('get')->willReturnMap([
+            ['config', $config],
+            ['plugin', $featureMock]
+        ]);
 
         $factory = new InMemoryEventStoreFactory();
         $factory($containerMock);

--- a/tests/Container/InMemoryProjectionManagerFactoryTest.php
+++ b/tests/Container/InMemoryProjectionManagerFactoryTest.php
@@ -19,9 +19,12 @@ use Prooph\EventStore\Exception\InvalidArgumentException;
 use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
 use Psr\Container\ContainerInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class InMemoryProjectionManagerFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/Example/QuickStartTest.php
+++ b/tests/Example/QuickStartTest.php
@@ -27,7 +27,7 @@ class QuickStartTest extends TestCase
             '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
         );
 
-        $this->assertRegExp($pattern, $this->getQuickstartOutput());
+        $this->assertMatchesRegularExpression($pattern, $this->getQuickstartOutput());
     }
 
     private function getQuickstartOutput(): string

--- a/tests/Metadata/MetadataEnricherAggregateTest.php
+++ b/tests/Metadata/MetadataEnricherAggregateTest.php
@@ -20,9 +20,12 @@ use Prooph\EventStore\Metadata\MetadataEnricher;
 use Prooph\EventStore\Metadata\MetadataEnricherAggregate;
 use ProophTest\EventStore\Mock\TestDomainEvent;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class MetadataEnricherAggregateTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/Metadata/MetadataEnricherPluginTest.php
+++ b/tests/Metadata/MetadataEnricherPluginTest.php
@@ -25,9 +25,12 @@ use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\TestDomainEvent;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class MetadataEnricherPluginTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/Plugin/PluginManagerTest.php
+++ b/tests/Plugin/PluginManagerTest.php
@@ -19,9 +19,12 @@ use ProophTest\EventStore\ActionEventEmitterEventStoreTestCase;
 use ProophTest\EventStore\Mock\EventLoggerPlugin;
 use ProophTest\EventStore\Mock\UserCreated;
 use Psr\Container\ContainerInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class PluginManagerTest extends ActionEventEmitterEventStoreTestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/Projection/AbstractEventStoreProjectorTest.php
+++ b/tests/Projection/AbstractEventStoreProjectorTest.php
@@ -777,13 +777,13 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
 
         $state = $projection->getState();
 
-        $this->assertInternalType('array', $state);
+        $this->assertIsArray($state);
 
         $projection->reset();
 
         $state2 = $projection->getState();
 
-        $this->assertInternalType('array', $state2);
+        $this->assertIsArray($state2);
     }
 
     /**

--- a/tests/Projection/AbstractEventStoreQueryTest.php
+++ b/tests/Projection/AbstractEventStoreQueryTest.php
@@ -300,13 +300,13 @@ abstract class AbstractEventStoreQueryTest extends TestCase
 
         $state = $query->getState();
 
-        $this->assertInternalType('array', $state);
+        $this->assertIsArray($state);
 
         $query->reset();
 
         $state2 = $query->getState();
 
-        $this->assertInternalType('array', $state2);
+        $this->assertIsArray($state2);
     }
 
     /**

--- a/tests/Projection/AbstractEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/AbstractEventStoreReadModelProjectorTest.php
@@ -418,13 +418,13 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
 
         $state = $projection->getState();
 
-        $this->assertInternalType('array', $state);
+        $this->assertIsArray($state);
 
         $projection->reset();
 
         $state2 = $projection->getState();
 
-        $this->assertInternalType('array', $state2);
+        $this->assertIsArray($state2);
     }
 
     /**

--- a/tests/Projection/InMemoryEventStoreProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectorTest.php
@@ -20,9 +20,12 @@ use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\NonTransactionalInMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryEventStoreProjector;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
 {
+    use ProphecyTrait;
+
     /**
      * @var InMemoryProjectionManager
      */

--- a/tests/Projection/InMemoryEventStoreQueryTest.php
+++ b/tests/Projection/InMemoryEventStoreQueryTest.php
@@ -20,9 +20,12 @@ use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\NonTransactionalInMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryEventStoreQuery;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class InMemoryEventStoreQueryTest extends AbstractEventStoreQueryTest
 {
+    use ProphecyTrait;
+
     /**
      * @var InMemoryProjectionManager
      */

--- a/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
@@ -21,9 +21,12 @@ use Prooph\EventStore\NonTransactionalInMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryEventStoreReadModelProjector;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
 use ProophTest\EventStore\Mock\ReadModelMock;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadModelProjectorTest
 {
+    use ProphecyTrait;
+
     /**
      * @var InMemoryProjectionManager
      */

--- a/tests/Projection/InMemoryProjectionManagerTest.php
+++ b/tests/Projection/InMemoryProjectionManagerTest.php
@@ -20,15 +20,18 @@ use Prooph\EventStore\Exception\RuntimeException;
 use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\NonTransactionalInMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class InMemoryProjectionManagerTest extends AbstractProjectionManagerTest
 {
+    use ProphecyTrait;
+
     /**
      * @var InMemoryProjectionManager
      */
     protected $projectionManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->projectionManager = new InMemoryProjectionManager(new InMemoryEventStore());
     }

--- a/tests/ReadOnlyEventStoreWrapperTest.php
+++ b/tests/ReadOnlyEventStoreWrapperTest.php
@@ -18,9 +18,12 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\ReadOnlyEventStoreWrapper;
 use Prooph\EventStore\StreamName;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ReadOnlyEventStoreWrapperTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/TransactionalActionEventEmitterEventStoreTest.php
+++ b/tests/TransactionalActionEventEmitterEventStoreTest.php
@@ -21,10 +21,12 @@ use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use Prooph\EventStore\TransactionalActionEventEmitterEventStore;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class TransactionalActionEventEmitterEventStoreTest extends TestCase
 {
     use EventStoreTestStreamTrait;
+    use ProphecyTrait;
 
     /**
      * @var TransactionalActionEventEmitterEventStore

--- a/tests/TransactionalEventStoreTestTrait.php
+++ b/tests/TransactionalEventStoreTestTrait.php
@@ -22,12 +22,15 @@ use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use Prooph\EventStore\TransactionalEventStore;
 use ProophTest\EventStore\Mock\UsernameChanged;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Common tests for all transactional event store implementations
  */
 trait TransactionalEventStoreTestTrait
 {
+    use ProphecyTrait;
+
     /**
      * @var TransactionalEventStore
      */

--- a/tests/Upcasting/NoOpEventUpcasterTest.php
+++ b/tests/Upcasting/NoOpEventUpcasterTest.php
@@ -16,9 +16,12 @@ namespace ProophTest\EventStore\Upcasting;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\Upcasting\NoOpEventUpcaster;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class NoOpEventUpcasterTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -30,7 +33,7 @@ class NoOpEventUpcasterTest extends TestCase
         $upcaster = new NoOpEventUpcaster();
 
         $messages = $upcaster->upcast($message);
-        $this->assertInternalType('array', $messages);
+        $this->assertIsArray($messages);
         $this->assertNotEmpty($messages);
         $this->assertSame($message, $messages[0]);
     }

--- a/tests/Upcasting/SingleEventUpcasterTest.php
+++ b/tests/Upcasting/SingleEventUpcasterTest.php
@@ -16,9 +16,12 @@ namespace ProophTest\EventStore\Upcasting;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\Upcasting\SingleEventUpcaster;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class SingleEventUpcasterTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -35,7 +38,7 @@ class SingleEventUpcasterTest extends TestCase
 
         $messages = $upcaster->upcast($message);
 
-        $this->assertInternalType('array', $messages);
+        $this->assertIsArray($messages);
         $this->assertNotEmpty($messages);
         $this->assertSame($upcastedMessage, $messages[0]);
     }
@@ -53,7 +56,7 @@ class SingleEventUpcasterTest extends TestCase
 
         $messages = $upcaster->upcast($message);
 
-        $this->assertInternalType('array', $messages);
+        $this->assertIsArray($messages);
         $this->assertNotEmpty($messages);
         $this->assertSame($message, $messages[0]);
     }

--- a/tests/Upcasting/UpcasterChainTest.php
+++ b/tests/Upcasting/UpcasterChainTest.php
@@ -19,9 +19,12 @@ use Prooph\EventStore\Upcasting\NoOpEventUpcaster;
 use Prooph\EventStore\Upcasting\SingleEventUpcaster;
 use Prooph\EventStore\Upcasting\Upcaster;
 use Prooph\EventStore\Upcasting\UpcasterChain;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class UpcasterChainTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -50,7 +53,7 @@ class UpcasterChainTest extends TestCase
 
         $messages = $upcasterChain->upcast($message);
 
-        $this->assertInternalType('array', $messages);
+        $this->assertIsArray($messages);
         $this->assertNotEmpty($messages);
         $this->assertSame($upcastedMessage2, $messages[0]);
         $this->assertSame($upcastedMessage3, $messages[1]);

--- a/tests/Upcasting/UpcastingIteratorTest.php
+++ b/tests/Upcasting/UpcastingIteratorTest.php
@@ -20,9 +20,12 @@ use Prooph\EventStore\StreamIterator\InMemoryStreamIterator;
 use Prooph\EventStore\StreamIterator\StreamIterator;
 use Prooph\EventStore\Upcasting\SingleEventUpcaster;
 use Prooph\EventStore\Upcasting\UpcastingIterator;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class UpcastingIteratorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */


### PR DESCRIPTION
Hello there,

Happy New Year :champagne: !!

Do you have any plan or suggestion to support PHP8 throughout the prooph ecosystem ?
I see that prooph/common is already supporting it.
Does it make sense to also support it within prooph/event-store and prooph/pdo-event-store ?

Regards.