### PR TITLE
Annotate tests that can be medium/large in pdo-event-store

### DIFF
--- a/tests/AbstractEventStoreTest.php
+++ b/tests/AbstractEventStoreTest.php
@@ -1014,6 +1014,7 @@ abstract class AbstractEventStoreTest extends TestCase
 
     /**
      * @test
+     * @medium
      */
     public function it_fetches_stream_names(): void
     {
@@ -1077,6 +1078,7 @@ abstract class AbstractEventStoreTest extends TestCase
 
     /**
      * @test
+     * @medium
      */
     public function it_fetches_stream_categories(): void
     {

--- a/tests/Projection/AbstractProjectionManagerTest.php
+++ b/tests/Projection/AbstractProjectionManagerTest.php
@@ -32,7 +32,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
 
     /**
      * @test
-     * @medium
+     * @large
      */
     public function it_fetches_projection_names(): void
     {
@@ -158,7 +158,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
 
     /**
      * @test
-     * @medium
+     * @large
      */
     public function it_fetches_projection_names_using_regex(): void
     {


### PR DESCRIPTION
Required for https://github.com/prooph/pdo-event-store/pull/228 . These tests run longer on a real database. 