### PR TITLE
ReflectionException may occur

### DIFF
--- a/src/Projection/InMemoryEventStoreProjector.php
+++ b/src/Projection/InMemoryEventStoreProjector.php
@@ -499,7 +499,7 @@ final class InMemoryEventStoreProjector implements Projector
         $reflectionProperty->setAccessible(true);
 
         $streamPositions = [];
-        $streams = \array_keys($reflectionProperty->getValue($this->eventStore));
+        $streams = \array_keys($reflectionProperty->getValue($this->innerEventStore));
 
         if (isset($this->query['all'])) {
             foreach ($streams as $stream) {


### PR DESCRIPTION
When making some changes in `prooph/event-store-symfony-bundle` I found that InMemoryEventStoreProjector throws a ReflectionException in certain situation. Defining a ProjectionManager with injected wrapped EventStore, $eventStore property doesn't contain an instance of the same class that $innerEventStore property was declared in.

It all started here: https://github.com/prooph/event-store-symfony-bundle/issues/73 :)