### PR TITLE
PHP 8.2 compatibility (and some more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prooph Event Store
 
-PHP 7.3 EventStore Implementation.
+PHP 7.4 EventStore Implementation.
 
 [![Build Status](https://travis-ci.com/prooph/event-store.svg?branch=7.x)](https://travis-ci.com/prooph/event-store)
 [![Coverage Status](https://coveralls.io/repos/prooph/event-store/badge.svg?branch=7.x&service=github)](https://coveralls.io/github/prooph/event-store?branch=7.x)

--- a/examples/event/QuickStartSucceeded.php
+++ b/examples/event/QuickStartSucceeded.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -23,10 +23,7 @@ use Prooph\EventStore\Util\Assertion;
  */
 final class QuickStartSucceeded extends DomainEvent
 {
-    /**
-     * @var string
-     */
-    private $text;
+    private string $text;
 
     public static function withSuccessMessage(string $text): QuickStartSucceeded
     {
@@ -46,6 +43,9 @@ final class QuickStartSucceeded extends DomainEvent
         return $this->text;
     }
 
+    /**
+     * @return array{text: string}
+     */
     public function payload(): array
     {
         return ['text' => $this->text];

--- a/examples/quickstart.php
+++ b/examples/quickstart.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/ActionEventEmitterEventStore.php
+++ b/src/ActionEventEmitterEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/InMemoryEventStoreFactory.php
+++ b/src/Container/InMemoryEventStoreFactory.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -42,15 +42,9 @@ final class InMemoryEventStoreFactory implements
 {
     use ConfigurationTrait;
 
-    /**
-     * @var string
-     */
-    private $configId;
+    private string $configId;
 
-    /**
-     * @var bool
-     */
-    private $isTransactional;
+    private ?bool $isTransactional = null;
 
     /**
      * Creates a new instance from a specified config, specifically meant to be used as static factory.
@@ -75,7 +69,7 @@ final class InMemoryEventStoreFactory implements
             );
         }
 
-        return (new static($name))->__invoke($arguments[0]);
+        return (new self($name))->__invoke($arguments[0]);
     }
 
     public function __construct(string $configId = 'default')
@@ -164,6 +158,7 @@ final class InMemoryEventStoreFactory implements
 
     /**
      * {@inheritdoc}
+     * @return array{metadata_enrichers: never[], plugins: never[], wrap_action_event_emitter: true, transactional: true, read_only: true}
      */
     public function defaultOptions(): iterable
     {

--- a/src/Container/InMemoryProjectionManagerFactory.php
+++ b/src/Container/InMemoryProjectionManagerFactory.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -29,10 +29,7 @@ final class InMemoryProjectionManagerFactory implements
 {
     use ConfigurationTrait;
 
-    /**
-     * @var string
-     */
-    private $configId;
+    private string $configId;
 
     /**
      * Creates a new instance from a specified config, specifically meant to be used as static factory.
@@ -57,7 +54,7 @@ final class InMemoryProjectionManagerFactory implements
             );
         }
 
-        return (new static($name))->__invoke($arguments[0]);
+        return (new self($name))->__invoke($arguments[0]);
     }
 
     public function __construct(string $configId = 'default')

--- a/src/EventStore.php
+++ b/src/EventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/EventStoreDecorator.php
+++ b/src/EventStoreDecorator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ConcurrencyException.php
+++ b/src/Exception/ConcurrencyException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/EventStoreException.php
+++ b/src/Exception/EventStoreException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ExtensionNotLoadedException.php
+++ b/src/Exception/ExtensionNotLoadedException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/OutOfRangeException.php
+++ b/src/Exception/OutOfRangeException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ProjectionNotFound.php
+++ b/src/Exception/ProjectionNotFound.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/StreamExistsAlready.php
+++ b/src/Exception/StreamExistsAlready.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/StreamNotFound.php
+++ b/src/Exception/StreamNotFound.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/TransactionAlreadyStarted.php
+++ b/src/Exception/TransactionAlreadyStarted.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/TransactionNotStarted.php
+++ b/src/Exception/TransactionNotStarted.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/InMemoryEventStore.php
+++ b/src/InMemoryEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -28,20 +28,11 @@ use Prooph\EventStore\Util\Assertion;
 
 final class InMemoryEventStore implements TransactionalEventStore
 {
-    /**
-     * @var array
-     */
-    private $streams = [];
+    private array $streams = [];
 
-    /**
-     * @var array
-     */
-    private $cachedStreams = [];
+    private array $cachedStreams = [];
 
-    /**
-     * @var bool
-     */
-    private $inTransaction = false;
+    private bool $inTransaction = false;
 
     public function create(Stream $stream): void
     {
@@ -512,12 +503,12 @@ final class InMemoryEventStore implements TransactionalEventStore
                 }
                 break;
             case Operator::GREATER_THAN():
-                if (! ($value > $expected)) {
+                if ($value <= $expected) {
                     return false;
                 }
                 break;
             case Operator::GREATER_THAN_EQUALS():
-                if (! ($value >= $expected)) {
+                if ($value < $expected) {
                     return false;
                 }
                 break;
@@ -527,12 +518,12 @@ final class InMemoryEventStore implements TransactionalEventStore
                 }
                 break;
             case Operator::LOWER_THAN():
-                if (! ($value < $expected)) {
+                if ($value >= $expected) {
                     return false;
                 }
                 break;
             case Operator::LOWER_THAN_EQUALS():
-                if (! ($value <= $expected)) {
+                if ($value > $expected) {
                     return false;
                 }
                 break;

--- a/src/Metadata/FieldType.php
+++ b/src/Metadata/FieldType.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/MetadataEnricher.php
+++ b/src/Metadata/MetadataEnricher.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/MetadataEnricherAggregate.php
+++ b/src/Metadata/MetadataEnricherAggregate.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -21,7 +21,7 @@ final class MetadataEnricherAggregate implements MetadataEnricher
     /**
      * @var MetadataEnricher[]
      */
-    private $metadataEnrichers;
+    private array $metadataEnrichers;
 
     /**
      * @param MetadataEnricher[] $metadataEnrichers

--- a/src/Metadata/MetadataEnricherPlugin.php
+++ b/src/Metadata/MetadataEnricherPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -22,10 +22,7 @@ use Prooph\EventStore\Stream;
 
 final class MetadataEnricherPlugin extends AbstractPlugin
 {
-    /**
-     * @var MetadataEnricher
-     */
-    private $metadataEnricher;
+    private MetadataEnricher $metadataEnricher;
 
     public function __construct(MetadataEnricher $metadataEnricher)
     {
@@ -36,13 +33,17 @@ final class MetadataEnricherPlugin extends AbstractPlugin
     {
         $this->listenerHandlers[] = $eventStore->attach(
             ActionEventEmitterEventStore::EVENT_CREATE,
-            [$this, 'onEventStoreCreateStream'],
+            function (ActionEvent $createEvent): void {
+                $this->onEventStoreCreateStream($createEvent);
+            },
             1000
         );
 
         $this->listenerHandlers[] = $eventStore->attach(
             ActionEventEmitterEventStore::EVENT_APPEND_TO,
-            [$this, 'onEventStoreAppendToStream'],
+            function (ActionEvent $appendToStreamEvent): void {
+                $this->onEventStoreAppendToStream($appendToStreamEvent);
+            },
             1000
         );
     }

--- a/src/Metadata/MetadataMatcher.php
+++ b/src/Metadata/MetadataMatcher.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -17,7 +17,7 @@ use Prooph\EventStore\Exception\InvalidArgumentException;
 
 class MetadataMatcher
 {
-    private $data = [];
+    private array $data = [];
 
     public function data(): array
     {

--- a/src/Metadata/Operator.php
+++ b/src/Metadata/Operator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/NonTransactionalInMemoryEventStore.php
+++ b/src/NonTransactionalInMemoryEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -26,15 +26,9 @@ use Prooph\EventStore\Util\Assertion;
 
 final class NonTransactionalInMemoryEventStore implements EventStore
 {
-    /**
-     * @var array
-     */
-    private $streams = [];
+    private array $streams = [];
 
-    /**
-     * @var array
-     */
-    private $cachedStreams = [];
+    private array $cachedStreams = [];
 
     public function create(Stream $stream): void
     {
@@ -434,12 +428,12 @@ final class NonTransactionalInMemoryEventStore implements EventStore
                 }
                 break;
             case Operator::GREATER_THAN():
-                if (! ($value > $expected)) {
+                if ($value <= $expected) {
                     return false;
                 }
                 break;
             case Operator::GREATER_THAN_EQUALS():
-                if (! ($value >= $expected)) {
+                if ($value < $expected) {
                     return false;
                 }
                 break;
@@ -449,12 +443,12 @@ final class NonTransactionalInMemoryEventStore implements EventStore
                 }
                 break;
             case Operator::LOWER_THAN():
-                if (! ($value < $expected)) {
+                if ($value >= $expected) {
                     return false;
                 }
                 break;
             case Operator::LOWER_THAN_EQUALS():
-                if (! ($value <= $expected)) {
+                if ($value > $expected) {
                     return false;
                 }
                 break;

--- a/src/Plugin/AbstractPlugin.php
+++ b/src/Plugin/AbstractPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Plugin/UpcastingPlugin.php
+++ b/src/Plugin/UpcastingPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -23,10 +23,7 @@ final class UpcastingPlugin extends AbstractPlugin
 {
     public const ACTION_EVENT_PRIORITY = -1000;
 
-    /**
-     * @var Upcaster
-     */
-    private $upcaster;
+    private Upcaster $upcaster;
 
     public function __construct(Upcaster $upcaster)
     {

--- a/src/Projection/AbstractReadModel.php
+++ b/src/Projection/AbstractReadModel.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/InMemoryProjectionManager.php
+++ b/src/Projection/InMemoryProjectionManager.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -21,10 +21,7 @@ use Prooph\EventStore\NonTransactionalInMemoryEventStore;
 
 final class InMemoryProjectionManager implements ProjectionManager
 {
-    /**
-     * @var EventStore
-     */
-    private $eventStore;
+    private EventStore $eventStore;
 
     /**
      * @var array
@@ -32,7 +29,7 @@ final class InMemoryProjectionManager implements ProjectionManager
      * key = projector name
      * value = projector instance
      */
-    private $projectors = [];
+    private array $projectors = [];
 
     public function __construct(EventStore $eventStore)
     {
@@ -43,10 +40,7 @@ final class InMemoryProjectionManager implements ProjectionManager
         }
 
         if (
-            ! (
-                $eventStore instanceof InMemoryEventStore
-                || $eventStore instanceof NonTransactionalInMemoryEventStore
-            )
+            ! $eventStore instanceof InMemoryEventStore && ! $eventStore instanceof NonTransactionalInMemoryEventStore
         ) {
             throw new Exception\InvalidArgumentException('Unknown event store instance given');
         }

--- a/src/Projection/ProjectionManager.php
+++ b/src/Projection/ProjectionManager.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/ProjectionStatus.php
+++ b/src/Projection/ProjectionStatus.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -25,10 +25,10 @@ use MabeEnum\Enum;
  */
 final class ProjectionStatus extends Enum
 {
-    const RUNNING = 'running';
-    const STOPPING = 'stopping';
-    const DELETING = 'deleting';
-    const DELETING_INCL_EMITTED_EVENTS = 'deleting incl emitted events';
-    const RESETTING = 'resetting';
-    const IDLE = 'idle';
+    public const RUNNING = 'running';
+    public const STOPPING = 'stopping';
+    public const DELETING = 'deleting';
+    public const DELETING_INCL_EMITTED_EVENTS = 'deleting incl emitted events';
+    public const RESETTING = 'resetting';
+    public const IDLE = 'idle';
 }

--- a/src/Projection/Projector.php
+++ b/src/Projection/Projector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/Query.php
+++ b/src/Projection/Query.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/ReadModel.php
+++ b/src/Projection/ReadModel.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/ReadModelProjector.php
+++ b/src/Projection/ReadModelProjector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/ReadOnlyEventStore.php
+++ b/src/ReadOnlyEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/ReadOnlyEventStoreWrapper.php
+++ b/src/ReadOnlyEventStoreWrapper.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -18,10 +18,7 @@ use Prooph\EventStore\Metadata\MetadataMatcher;
 
 final class ReadOnlyEventStoreWrapper implements ReadOnlyEventStore
 {
-    /**
-     * @var EventStore
-     */
-    private $eventStore;
+    private EventStore $eventStore;
 
     public function __construct(EventStore $eventStore)
     {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/EmptyStreamIterator.php
+++ b/src/StreamIterator/EmptyStreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/InMemoryStreamIterator.php
+++ b/src/StreamIterator/InMemoryStreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/MergedStreamIterator.php
+++ b/src/StreamIterator/MergedStreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -17,20 +17,11 @@ class MergedStreamIterator implements StreamIterator
 {
     use TimSort;
 
-    /**
-     * @var array
-     */
-    private $iterators = [];
+    private array $iterators = [];
 
-    /**
-     * @var int
-     */
-    private $numberOfIterators;
+    private int $numberOfIterators;
 
-    /**
-     * @var array
-     */
-    private $originalIteratorOrder;
+    private array $originalIteratorOrder;
 
     public function __construct(array $streamNames, StreamIterator ...$iterators)
     {

--- a/src/StreamIterator/StreamIterator.php
+++ b/src/StreamIterator/StreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/TimSort.php
+++ b/src/StreamIterator/TimSort.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -146,7 +146,7 @@ trait TimSort
         $bValid = $b->valid();
 
         if (! $aValid || ! $bValid) {
-            return $bValid === true;
+            return $bValid;
         }
 
         return $a->current()->createdAt() > $b->current()->createdAt();
@@ -158,7 +158,7 @@ trait TimSort
         $bValid = $b->valid();
 
         if (! $aValid || ! $bValid) {
-            return $aValid === true;
+            return $aValid;
         }
 
         return $a->current()->createdAt() <= $b->current()->createdAt();

--- a/src/StreamName.php
+++ b/src/StreamName.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/TransactionalActionEventEmitterEventStore.php
+++ b/src/TransactionalActionEventEmitterEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/TransactionalEventStore.php
+++ b/src/TransactionalEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/NoOpEventUpcaster.php
+++ b/src/Upcasting/NoOpEventUpcaster.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/SingleEventUpcaster.php
+++ b/src/Upcasting/SingleEventUpcaster.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/Upcaster.php
+++ b/src/Upcasting/Upcaster.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/UpcasterChain.php
+++ b/src/Upcasting/UpcasterChain.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -20,7 +20,7 @@ final class UpcasterChain implements Upcaster
     /**
      * @var Upcaster[]
      */
-    private $upcasters;
+    private array $upcasters;
 
     public function __construct(Upcaster ...$upcasters)
     {

--- a/src/Upcasting/UpcastingIterator.php
+++ b/src/Upcasting/UpcastingIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -18,20 +18,11 @@ use Prooph\EventStore\StreamIterator\StreamIterator;
 
 final class UpcastingIterator implements StreamIterator
 {
-    /**
-     * @var Upcaster
-     */
-    private $upcaster;
+    private Upcaster $upcaster;
 
-    /**
-     * @var StreamIterator
-     */
-    private $innerIterator;
+    private StreamIterator $innerIterator;
 
-    /**
-     * @var array
-     */
-    private $storedMessages = [];
+    private array $storedMessages = [];
 
     public function __construct(Upcaster $upcaster, StreamIterator $iterator)
     {
@@ -110,7 +101,6 @@ final class UpcastingIterator implements StreamIterator
     {
         $this->storedMessages = [];
         $this->innerIterator->rewind();
-        $this->position = 0;
     }
 
     public function count(): int

--- a/src/Util/ArrayCache.php
+++ b/src/Util/ArrayCache.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -15,20 +15,11 @@ namespace Prooph\EventStore\Util;
 
 class ArrayCache
 {
-    /**
-     * @var array
-     */
-    private $container = [];
+    private array $container;
 
-    /**
-     * @var int
-     */
-    private $size;
+    private int $size;
 
-    /**
-     * @var int
-     */
-    private $position = -1;
+    private int $position = -1;
 
     public function __construct(int $size)
     {

--- a/src/Util/Assertion.php
+++ b/src/Util/Assertion.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/AbstractEventStoreTest.php
+++ b/tests/AbstractEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/ActionEventEmitterEventStoreTest.php
+++ b/tests/ActionEventEmitterEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -457,7 +457,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
 
         $this->eventStore->attach(
             ActionEventEmitterEventStore::EVENT_FETCH_STREAM_METADATA,
-            function (ActionEvent $event) {
+            function (ActionEvent $event): void {
                 $event->stopPropagation();
             },
             1000

--- a/tests/ActionEventEmitterEventStoreTestCase.php
+++ b/tests/ActionEventEmitterEventStoreTestCase.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/InMemoryEventStoreFactoryTest.php
+++ b/tests/Container/InMemoryEventStoreFactoryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/InMemoryProjectionManagerFactoryTest.php
+++ b/tests/Container/InMemoryProjectionManagerFactoryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/EventStoreTestStreamTrait.php
+++ b/tests/EventStoreTestStreamTrait.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Example/QuickStartTest.php
+++ b/tests/Example/QuickStartTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/InMemoryEventStoreTest.php
+++ b/tests/InMemoryEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Metadata/MetadataEnricherAggregateTest.php
+++ b/tests/Metadata/MetadataEnricherAggregateTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Metadata/MetadataEnricherPluginTest.php
+++ b/tests/Metadata/MetadataEnricherPluginTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Metadata/MetadataMatcherTest.php
+++ b/tests/Metadata/MetadataMatcherTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/EventLoggerPlugin.php
+++ b/tests/Mock/EventLoggerPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -20,10 +20,7 @@ use Prooph\EventStore\Plugin\AbstractPlugin;
 
 class EventLoggerPlugin extends AbstractPlugin
 {
-    /**
-     * @var Iterator
-     */
-    protected $loggedStreamEvents;
+    protected \Iterator $loggedStreamEvents;
 
     public function __construct()
     {

--- a/tests/Mock/Post.php
+++ b/tests/Mock/Post.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -16,33 +16,24 @@ namespace ProophTest\EventStore\Mock;
 use Prooph\Common\Messaging\DomainEvent;
 use Prooph\Common\Messaging\Message;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 class Post
 {
-    /**
-     * @var Uuid
-     */
-    private $postId;
+    private string $name;
+
+    private ?UuidInterface $postId = null;
+
+    private string $text;
+
+    private string $email;
 
     /**
-     * @var string
+     * @var DomainEvent[]|null
      */
-    private $text;
+    private ?array $recordedEvents = null;
 
-    /**
-     * @var string
-     */
-    private $email;
-
-    /**
-     * @var DomainEvent[]
-     */
-    private $recordedEvents;
-
-    /**
-     * @var int
-     */
-    private $version = 0;
+    private int $version = 0;
 
     public static function create(string $text, string $email): Post
     {
@@ -61,7 +52,7 @@ class Post
     }
 
     /**
-     * @param Message[] $historyEvents
+     * @param DomainEvent[] $historyEvents
      * @return Post
      */
     public static function reconstituteFromHistory(array $historyEvents): Post
@@ -77,9 +68,6 @@ class Post
     {
     }
 
-    /**
-     * @return Uuid
-     */
     public function getId(): Uuid
     {
         return $this->postId;
@@ -124,7 +112,7 @@ class Post
     /**
      * @param DomainEvent[] $streamEvents
      */
-    private function replay($streamEvents): void
+    private function replay(array $streamEvents): void
     {
         foreach ($streamEvents as $streamEvent) {
             $this->apply($streamEvent);

--- a/tests/Mock/PostCreated.php
+++ b/tests/Mock/PostCreated.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/Product.php
+++ b/tests/Mock/Product.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/ReadModelMock.php
+++ b/tests/Mock/ReadModelMock.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -18,12 +18,9 @@ use Prooph\EventStore\Projection\AbstractReadModel;
 
 class ReadModelMock extends AbstractReadModel
 {
-    private $storage;
+    private ?array $storage = null;
 
-    /**
-     * @var array
-     */
-    private $stack = [];
+    private array $stack = [];
 
     public function insert(string $key, $value): void
     {

--- a/tests/Mock/TestDomainEvent.php
+++ b/tests/Mock/TestDomainEvent.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/TestIteratorAggregate.php
+++ b/tests/Mock/TestIteratorAggregate.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/User.php
+++ b/tests/Mock/User.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -16,33 +16,22 @@ namespace ProophTest\EventStore\Mock;
 use Iterator;
 use Prooph\Common\Messaging\DomainEvent;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 class User
 {
-    /**
-     * @var Uuid
-     */
-    private $userId;
+    private ?UuidInterface $userId = null;
+
+    private string $name;
+
+    private string $email;
 
     /**
-     * @var string
+     * @var DomainEvent[]|null
      */
-    private $name;
+    private ?array $recordedEvents = null;
 
-    /**
-     * @var string
-     */
-    private $email;
-
-    /**
-     * @var DomainEvent[]
-     */
-    private $recordedEvents;
-
-    /**
-     * @var int
-     */
-    private $version = 0;
+    private int $version = 0;
 
     public static function create(string $name, string $email): User
     {
@@ -93,7 +82,7 @@ class User
         return $this->email;
     }
 
-    public function changeName(string $newName)
+    public function changeName(string $newName): void
     {
         $this->recordThat(UsernameChanged::with(
             [

--- a/tests/Mock/UserCreated.php
+++ b/tests/Mock/UserCreated.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/UsernameChanged.php
+++ b/tests/Mock/UsernameChanged.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/NonTransactionalInMemoryEventStoreTest.php
+++ b/tests/NonTransactionalInMemoryEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Plugin/PluginManagerTest.php
+++ b/tests/Plugin/PluginManagerTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Plugin/UpcastingPluginTest.php
+++ b/tests/Plugin/UpcastingPluginTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractEventStoreProjectorTest.php
+++ b/tests/Projection/AbstractEventStoreProjectorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractEventStoreQueryTest.php
+++ b/tests/Projection/AbstractEventStoreQueryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/AbstractEventStoreReadModelProjectorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -1118,14 +1118,14 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_reset_projection_also_if_init_callback_returns_state()
+    public function it_calls_reset_projection_also_if_init_callback_returns_state(): void
     {
         $readModel = $this->prophesize(ReadModel::class);
         $readModel->reset()->shouldBeCalled();
 
         $readModelProjection = $this->projectionManager->createReadModelProjection('test-projection', $readModel->reveal());
 
-        $readModelProjection->init(function () {
+        $readModelProjection->init(function (): array {
             return ['state' => 'some value'];
         });
 

--- a/tests/Projection/AbstractProjectionManagerTest.php
+++ b/tests/Projection/AbstractProjectionManagerTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryEventStoreProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryEventStoreQueryTest.php
+++ b/tests/Projection/InMemoryEventStoreQueryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryProjectionManagerTest.php
+++ b/tests/Projection/InMemoryProjectionManagerTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/isolated-long-running-projection.php
+++ b/tests/Projection/isolated-long-running-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -37,13 +37,13 @@ $projection = $projectionManager->createProjection(
         Projector::OPTION_PCNTL_DISPATCH => true,
     ]
 );
-\pcntl_signal(SIGQUIT, function () use ($projection) {
+\pcntl_signal(SIGQUIT, function () use ($projection): void {
     $projection->stop();
     exit(SIGUSR1);
 });
 $projection
     ->fromStream('user-123')
-    ->whenAny(function () {
+    ->whenAny(function (): void {
         \usleep(500000);
     })
     ->run();

--- a/tests/Projection/isolated-long-running-query.php
+++ b/tests/Projection/isolated-long-running-query.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -37,14 +37,14 @@ $query = $projectionManager->createQuery(
     ]
 );
 
-\pcntl_signal(SIGQUIT, function () use ($query) {
+\pcntl_signal(SIGQUIT, function () use ($query): void {
     $query->stop();
     exit(SIGUSR1);
 });
 
 $query
     ->fromStreams('user-123')
-    ->whenAny(function () {
+    ->whenAny(function (): void {
         \usleep(500000);
     })
     ->run();

--- a/tests/Projection/isolated-long-running-read-model-projection.php
+++ b/tests/Projection/isolated-long-running-read-model-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -66,13 +66,13 @@ $projection = $projectionManager->createReadModelProjection(
         ReadModelProjector::OPTION_PCNTL_DISPATCH => true,
     ]
 );
-\pcntl_signal(SIGQUIT, function () use ($projection) {
+\pcntl_signal(SIGQUIT, function () use ($projection): void {
     $projection->stop();
     exit(SIGUSR1);
 });
 $projection
     ->fromStream('user-123')
-    ->whenAny(function () {
+    ->whenAny(function (): void {
         \usleep(500000);
     })
     ->run();

--- a/tests/Projection/isolated-projection.php
+++ b/tests/Projection/isolated-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -29,12 +29,12 @@ $projection = $projectionManager->createProjection(
         Projector::OPTION_PCNTL_DISPATCH => true,
     ]
 );
-\pcntl_signal(SIGQUIT, function () use ($projection) {
+\pcntl_signal(SIGQUIT, function () use ($projection): void {
     $projection->stop();
     exit(SIGUSR1);
 });
 $projection
     ->fromStream('user-123')
-    ->whenAny(function () {
+    ->whenAny(function (): void {
     })
     ->run();

--- a/tests/Projection/isolated-read-model-projection.php
+++ b/tests/Projection/isolated-read-model-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -58,12 +58,12 @@ $projection = $projectionManager->createReadModelProjection(
         ReadModelProjector::OPTION_PCNTL_DISPATCH => true,
     ]
 );
-\pcntl_signal(SIGQUIT, function () use ($projection) {
+\pcntl_signal(SIGQUIT, function () use ($projection): void {
     $projection->stop();
     exit(SIGUSR1);
 });
 $projection
     ->fromStream('user-123')
-    ->whenAny(function () {
+    ->whenAny(function (): void {
     })
     ->run();

--- a/tests/ReadOnlyEventStoreWrapperTest.php
+++ b/tests/ReadOnlyEventStoreWrapperTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/AbstractStreamIteratorTest.php
+++ b/tests/StreamIterator/AbstractStreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/EmptyStreamIteratorTest.php
+++ b/tests/StreamIterator/EmptyStreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/InMemoryStreamIteratorTest.php
+++ b/tests/StreamIterator/InMemoryStreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/MergedStreamIteratorTest.php
+++ b/tests/StreamIterator/MergedStreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -120,7 +120,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
         $streamsTwoEvents = \array_chunk(\array_slice($datetimeList, $chunkThree, $length), 2);
         $streamsOneEvents = \array_chunk(\array_slice($datetimeList, $length + $chunkThree), 1);
 
-        $streamEvents = \array_merge($streamsOneEvents, $streamsTwoEvents, $streamsThreeEvents);
+        $streamEvents = [...$streamsOneEvents, ...$streamsTwoEvents, ...$streamsThreeEvents];
         \shuffle($streamEvents);
 
         $streams = [];
@@ -130,7 +130,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
             $streamName = 'stream' . $streamNo;
 
             // must be sorted
-            \usort($stream, static function ($a, $b) {
+            \usort($stream, static function ($a, $b): int {
                 return $a['payload']['expected_index'] <=> $b['payload']['expected_index'];
             });
 

--- a/tests/StreamNameTest.php
+++ b/tests/StreamNameTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/TransactionalActionEventEmitterEventStoreTest.php
+++ b/tests/TransactionalActionEventEmitterEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -128,7 +128,7 @@ class TransactionalActionEventEmitterEventStoreTest extends TestCase
      */
     public function it_wraps_up_code_in_transaction_properly(): void
     {
-        $transactionResult = $this->eventStore->transactional(function () {
+        $transactionResult = $this->eventStore->transactional(function (): string {
             $this->eventStore->create($this->getTestStream());
 
             return 'Result';

--- a/tests/TransactionalEventStoreTestTrait.php
+++ b/tests/TransactionalEventStoreTestTrait.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -64,7 +64,7 @@ trait TransactionalEventStoreTestTrait
      */
     public function it_wraps_up_code_in_transaction_properly(): void
     {
-        $transactionResult = $this->eventStore->transactional(function (EventStore $eventStore) {
+        $transactionResult = $this->eventStore->transactional(function (EventStore $eventStore): string {
             $this->eventStore->create($this->getTestStream());
             $this->assertSame($this->eventStore, $eventStore);
 
@@ -78,7 +78,7 @@ trait TransactionalEventStoreTestTrait
             2
         );
 
-        $transactionResult = $this->eventStore->transactional(function (EventStore $eventStore) use ($secondStreamEvent) {
+        $transactionResult = $this->eventStore->transactional(function (EventStore $eventStore) use ($secondStreamEvent): string {
             $this->eventStore->appendTo(new StreamName('Prooph\Model\User'), new ArrayIterator([$secondStreamEvent]));
             $this->assertSame($this->eventStore, $eventStore);
 
@@ -127,7 +127,7 @@ trait TransactionalEventStoreTestTrait
 
         $eventStore = $this->eventStore;
 
-        $this->eventStore->transactional(function (EventStore $es) use ($eventStore) {
+        $this->eventStore->transactional(function (EventStore $es) use ($eventStore): void {
             $this->assertSame($es, $eventStore);
             throw new \Exception('Transaction failed');
         });
@@ -138,7 +138,7 @@ trait TransactionalEventStoreTestTrait
      */
     public function it_should_return_true_by_default_if_transaction_is_used(): void
     {
-        $transactionResult = $this->eventStore->transactional(function (EventStore $eventStore) {
+        $transactionResult = $this->eventStore->transactional(function (EventStore $eventStore): void {
             $this->eventStore->create($this->getTestStream());
             $this->assertSame($this->eventStore, $eventStore);
         });

--- a/tests/Upcasting/NoOpEventUpcasterTest.php
+++ b/tests/Upcasting/NoOpEventUpcasterTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Upcasting/SingleEventUpcasterTest.php
+++ b/tests/Upcasting/SingleEventUpcasterTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Upcasting/UpcasterChainTest.php
+++ b/tests/Upcasting/UpcasterChainTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -62,7 +62,7 @@ class UpcasterChainTest extends TestCase
     /**
      * @test
      */
-    public function it_doesnt_remove_messages_when_a_subsequent_upcaster_returns_fewer_messages()
+    public function it_doesnt_remove_messages_when_a_subsequent_upcaster_returns_fewer_messages(): void
     {
         $initialMessage = $this->prophesize(Message::class);
         $initialMessage->payload()->willReturn(['name' => 'initialMessage']);
@@ -106,7 +106,7 @@ class UpcasterChainTest extends TestCase
             ['name' => 'subsequentMessage-modified'],
             ['name' => 'furtherSubsequentMessage'],
         ];
-        $messagePayloads = \array_map(function (Message $message) {
+        $messagePayloads = \array_map(function (Message $message): array {
             return $message->payload();
         }, $messages);
 

--- a/tests/Upcasting/UpcastingIteratorTest.php
+++ b/tests/Upcasting/UpcastingIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Util/ArrayCacheTest.php
+++ b/tests/Util/ArrayCacheTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2022 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2022 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2023 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2023 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
Most of these changes are done with the help of [rector](https://github.com/rectorphp/rector).

  * Ensure compatibility with PHP 8.2 (dynamic properties)
  * Add explicit public visibility to remaining constants
  * Use array spread operator instead of array_merge where possible
  * Add null default to nullable properties properties that have no default
  * Add typed properties and return types where possible
  * Simplify empty() function calls on empty arrays
  * Update licenses to 2023