### PR TITLE
Make sure test classes are included in the package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,13 +52,10 @@
     },
     "autoload": {
         "psr-4": {
-            "Prooph\\EventStore\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
+            "Prooph\\EventStore\\": "src/",
             "ProophTest\\EventStore\\": "tests/"
-        }
+        },
+        "exclude-from-classmap": ["tests/"]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This makes sure test classes are included in the package when used as a dependency.

By also adding "tests/" to the "exclude-from-classmap" directive the test files are excluded from the optimized classmap which is usually done in the live production to speed up performance while the test files are still resolvable by composer by the psr-4 autoloading standard.