### PR TITLE
Allow to configure MetadataMatcher separately for ReadModelProjector

### DIFF
--- a/src/Projection/InMemoryEventStoreReadModelProjector.php
+++ b/src/Projection/InMemoryEventStoreReadModelProjector.php
@@ -131,14 +131,25 @@ final class InMemoryEventStoreReadModelProjector implements ReadModelProjector
         return $this;
     }
 
-    public function fromStream(string $streamName, ?MetadataMatcher $metadataMatcher = null): ReadModelProjector
+    public function withMetadataMatcher(?MetadataMatcher $metadataMatcher = null): ReadModelProjector
+    {
+        $this->metadataMatcher = $metadataMatcher;
+
+        return $this;
+    }
+
+    public function fromStream(string $streamName/**, ?MetadataMatcher $metadataMatcher = null*/): ReadModelProjector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
         }
 
+        if (\func_num_args() > 1) {
+            \trigger_error('The $metadataMatcher parameter is deprecated. Use withMetadataMatcher() instead.', E_USER_DEPRECATED);
+            $this->metadataMatcher = \func_get_arg(1);
+        }
+
         $this->query['streams'][] = $streamName;
-        $this->metadataMatcher = $metadataMatcher;
 
         return $this;
     }

--- a/src/Projection/ReadModelProjector.php
+++ b/src/Projection/ReadModelProjector.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Projection;
 
 use Closure;
+use Prooph\EventStore\Metadata\MetadataMatcher;
 
 interface ReadModelProjector
 {
@@ -45,6 +46,8 @@ interface ReadModelProjector
      * The callback has to return an array
      */
     public function init(Closure $callback): ReadModelProjector;
+
+    public function withMetadataMatcher(?MetadataMatcher $metadataMatcher = null): ReadModelProjector;
 
     public function fromStream(string $streamName): ReadModelProjector;
 
@@ -79,7 +82,7 @@ interface ReadModelProjector
      *     return $state;
      * }
      */
-    public function whenAny(Closure $closure): ReadModelProjector;
+    public function whenAny(Closure $handler): ReadModelProjector;
 
     public function reset(): void;
 


### PR DESCRIPTION
Allow to configure MetadataMatcher separately for ReadModelProjector. 

Certain metadata can be global, shared between streams. 