### PR TITLE
PHPUnit compatibility

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -60,7 +60,7 @@ jobs:
           - php: 8.4
             dependencies: ''
           - php: 8.4
-            depdendencies: '--prefer-lowest --prefer-stable'
+            dependencies: '--prefer-lowest --prefer-stable'
 
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -29,15 +29,14 @@
         "prooph/common": "^4.6.0"
     },
     "require-dev": {
+        "php-coveralls/php-coveralls": "^2.7",
         "phpspec/prophecy": "^1.10.3",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/php-invoker": "^3.1",
-        "phpunit/phpunit": "^9.6 || ^10.0",
+        "phpunit/phpunit": "^10.0",
         "prooph/bookdown-template": "^0.2.3",
         "prooph/php-cs-fixer-config": "^0.7.0",
         "psr/container": "^1.0",
-        "sandrokeil/interop-config": "^2.0.1",
-        "php-coveralls/php-coveralls": "^2.7"
+        "sandrokeil/interop-config": "^2.0.1"
     },
     "suggest": {
         "prooph/pdo-event-store": "For usage with MySQL or Postgres as event store",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         backupGlobals="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="vendor/autoload.php"
-         timeoutForSmallTests="2"
-         enforceTimeLimit="true"
          failOnWarning="true"
          failOnRisky="true"
          timeoutForLargeTests="180"
+         backupStaticProperties="false"
 >
     <testsuite name="Prooph EventStore Test Suite">
         <directory>./tests</directory>
     </testsuite>
-
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/tests/AbstractActionEventEmitterEventStoreTestCase.php
+++ b/tests/AbstractActionEventEmitterEventStoreTestCase.php
@@ -18,12 +18,9 @@ use Prooph\Common\Event\ProophActionEventEmitter;
 use Prooph\EventStore\ActionEventEmitterEventStore;
 use Prooph\EventStore\InMemoryEventStore;
 
-abstract class ActionEventEmitterEventStoreTestCase extends TestCase
+abstract class AbstractActionEventEmitterEventStoreTestCase extends TestCase
 {
-    /**
-     * @var ActionEventEmitterEventStore
-     */
-    protected $eventStore;
+    protected ActionEventEmitterEventStore $eventStore;
 
     protected function setUp(): void
     {

--- a/tests/AbstractEventStoreTestCase.php
+++ b/tests/AbstractEventStoreTestCase.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace ProophTest\EventStore;
 
 use ArrayIterator;
+use EmptyIterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Exception\InvalidArgumentException;
@@ -29,23 +32,20 @@ use ProophTest\EventStore\Mock\TestDomainEvent;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
 use Prophecy\PhpUnit\ProphecyTrait;
+use stdClass;
+use UnexpectedValueException;
 
 /**
  * Common tests for all event store implementations
  */
-abstract class AbstractEventStoreTest extends TestCase
+abstract class AbstractEventStoreTestCase extends TestCase
 {
     use EventStoreTestStreamTrait;
     use ProphecyTrait;
 
-    /**
-     * @var EventStore
-     */
-    protected $eventStore;
+    protected EventStore $eventStore;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_a_new_stream_and_records_the_stream_events_and_deletes(): void
     {
         $streamName = new StreamName('Prooph\Model\User');
@@ -72,9 +72,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertFalse($this->eventStore->hasStream($streamName));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_appends_events_to_stream_and_records_them(): void
     {
         $this->eventStore->create($this->getTestStream());
@@ -89,9 +87,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertCount(2, $this->eventStore->load(new StreamName('Prooph\Model\User')));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_cannot_create_a_stream_with_same_name_twice(): void
     {
         $this->expectException(StreamExistsAlready::class);
@@ -102,9 +98,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->eventStore->create($stream);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_updates_stream_metadata(): void
     {
         $stream = $this->getTestStream();
@@ -121,9 +115,7 @@ abstract class AbstractEventStoreTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_stream_not_found_exception_when_trying_to_update_metadata_on_unknown_stream(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -131,9 +123,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->eventStore->updateStreamMetadata(new StreamName('unknown'), []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_loads_events_from_number(): void
     {
         $stream = $this->getTestStream();
@@ -177,9 +167,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertFalse($streamEvents->current()->metadata()['snapshot']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_loads_events_reverse_from_number(): void
     {
         $stream = $this->getTestStream();
@@ -223,9 +211,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertTrue($streamEvents->current()->metadata()['snapshot']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_loads_events_from_number_with_count(): void
     {
         $stream = $this->getTestStream();
@@ -280,9 +266,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertFalse($loadedEvents->current()->metadata()['snapshot']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_loads_events_reverse_from_number_with_count(): void
     {
         $stream = $this->getTestStream();
@@ -337,10 +321,8 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertTrue($loadedEvents->current()->metadata()['snapshot']);
     }
 
-    /**
-     * @test
-     * @dataProvider getMatchingMetadata
-     */
+    #[DataProvider('getMatchingMetadata')]
+    #[Test]
     public function it_loads_events_by_matching_metadata(array $metadata): void
     {
         $stream = $this->getTestStream();
@@ -377,10 +359,8 @@ abstract class AbstractEventStoreTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     * @dataProvider getMatchingMetadata
-     */
+    #[DataProvider('getMatchingMetadata')]
+    #[Test]
     public function it_loads_events_reverse_by_matching_metadata(array $metadata): void
     {
         $stream = $this->getTestStream();
@@ -417,9 +397,7 @@ abstract class AbstractEventStoreTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_only_matched_metadata(): void
     {
         $event = UserCreated::with(['name' => 'John'], 1);
@@ -463,9 +441,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertCount(1, $streamEvents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_only_matched_metadata_2(): void
     {
         $event = UserCreated::with(['name' => 'John'], 1);
@@ -482,7 +458,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $stream = $this->prophesize(Stream::class);
         $stream->streamName()->willReturn($streamName)->shouldBeCalled();
         $stream->metadata()->willReturn([])->shouldBeCalled();
-        $stream->streamEvents()->willReturn(new \ArrayIterator([$event]))->shouldBeCalled();
+        $stream->streamEvents()->willReturn(new ArrayIterator([$event]))->shouldBeCalled();
 
         $this->eventStore->create($stream->reveal());
 
@@ -529,9 +505,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertFalse($result->valid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_only_matched_metadata_reverse(): void
     {
         $event = UserCreated::with(['name' => 'John'], 1);
@@ -577,9 +551,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertCount(1, $streamEvents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_only_matched_metadata_2_reverse(): void
     {
         $event = UserCreated::with(['name' => 'John'], 1);
@@ -596,7 +568,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $stream = $this->prophesize(Stream::class);
         $stream->streamName()->willReturn($streamName)->shouldBeCalled();
         $stream->metadata()->willReturn([])->shouldBeCalled();
-        $stream->streamEvents()->willReturn(new \ArrayIterator([$event]))->shouldBeCalled();
+        $stream->streamEvents()->willReturn(new ArrayIterator([$event]))->shouldBeCalled();
 
         $this->eventStore->create($stream->reveal());
 
@@ -679,16 +651,14 @@ abstract class AbstractEventStoreTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        $value = new \stdClass();
+        $value = new stdClass();
         $value->foo = 'bar';
 
         $metadataMatcher = new MetadataMatcher();
         $metadataMatcher->withMetadataMatch('meta', Operator::EQUALS(), $value);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_only_matched_message_property(): void
     {
         $event = UserCreated::with(['name' => 'John'], 1);
@@ -782,9 +752,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertFalse($result->valid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_only_matched_message_property_reverse(): void
     {
         $event = UserCreated::with(['name' => 'John'], 1);
@@ -875,9 +843,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertFalse($result->valid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_loads_empty_stream(): void
     {
         $streamName = new StreamName('Prooph\Model\User');
@@ -889,9 +855,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertFalse($it->valid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_loads_reverse_empty_stream(): void
     {
         $streamName = new StreamName('Prooph\Model\User');
@@ -903,9 +867,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertFalse($it->valid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_stream_not_found_exception_if_it_loads_nothing(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -915,9 +877,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->eventStore->load($stream->streamName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_stream_not_found_exception_if_it_loads_nothing_reverse(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -927,9 +887,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->eventStore->loadReverse($stream->streamName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_asked_for_unknown_stream_metadata(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -937,9 +895,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->eventStore->fetchStreamMetadata(new StreamName('unknown'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_metadata_when_asked_for_stream_metadata(): void
     {
         $stream = new Stream(new StreamName('Prooph\Model\User'), new ArrayIterator(), ['foo' => 'bar']);
@@ -949,9 +905,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $this->eventStore->fetchStreamMetadata($stream->streamName()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_delete_unknown_stream(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -959,9 +913,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->eventStore->delete(new StreamName('unknown'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_append_on_non_existing_stream(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -971,9 +923,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->eventStore->appendTo(new StreamName('unknown'), new ArrayIterator([$event]));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_load_non_existing_stream(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -984,9 +934,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->eventStore->load($streamName->reveal());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_stream(): void
     {
         $stream = $this->getTestStream();
@@ -998,9 +946,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertFalse($this->eventStore->hasStream($stream->streamName()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_check_for_stream_existence(): void
     {
         $streamName = new StreamName('Prooph\Model\User');
@@ -1012,9 +958,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertTrue($this->eventStore->hasStream($streamName));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_stream_names(): void
     {
         $streamNames = [];
@@ -1023,14 +967,14 @@ abstract class AbstractEventStoreTest extends TestCase
             for ($i = 0; $i < 50; $i++) {
                 $streamNames[] = 'user-' . $i;
                 $streamNames[] = 'admin-' . $i;
-                $this->eventStore->create(new Stream(new StreamName('user-' . $i), new \EmptyIterator(), ['foo' => 'bar']));
-                $this->eventStore->create(new Stream(new StreamName('admin-' . $i), new \EmptyIterator(), ['foo' => 'bar']));
+                $this->eventStore->create(new Stream(new StreamName('user-' . $i), new EmptyIterator(), ['foo' => 'bar']));
+                $this->eventStore->create(new Stream(new StreamName('admin-' . $i), new EmptyIterator(), ['foo' => 'bar']));
             }
 
             for ($i = 0; $i < 20; $i++) {
                 $streamName = \uniqid('rand');
                 $streamNames[] = $streamName;
-                $this->eventStore->create(new Stream(new StreamName($streamName), new \EmptyIterator()));
+                $this->eventStore->create(new Stream(new StreamName($streamName), new EmptyIterator()));
             }
 
             $this->assertCount(1, $this->eventStore->fetchStreamNames('user-0', null, 200, 0));
@@ -1064,9 +1008,7 @@ abstract class AbstractEventStoreTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_fetching_stream_names_using_invalid_regex(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -1075,9 +1017,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->eventStore->fetchStreamNamesRegex('/invalid)/', null, 10, 0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_stream_categories(): void
     {
         $streamNames = [];
@@ -1091,19 +1031,19 @@ abstract class AbstractEventStoreTest extends TestCase
                 $streamNames[] = 'foobar-' . $i;
                 $streamNames[] = 'foobaz-' . $i;
                 $streamNames[] = 'foobam-' . $i;
-                $this->eventStore->create(new Stream(new StreamName('foo-' . $i), new \EmptyIterator()));
-                $this->eventStore->create(new Stream(new StreamName('bar-' . $i), new \EmptyIterator()));
-                $this->eventStore->create(new Stream(new StreamName('baz-' . $i), new \EmptyIterator()));
-                $this->eventStore->create(new Stream(new StreamName('bam-' . $i), new \EmptyIterator()));
-                $this->eventStore->create(new Stream(new StreamName('foobar-' . $i), new \EmptyIterator()));
-                $this->eventStore->create(new Stream(new StreamName('foobaz-' . $i), new \EmptyIterator()));
-                $this->eventStore->create(new Stream(new StreamName('foobam-' . $i), new \EmptyIterator()));
+                $this->eventStore->create(new Stream(new StreamName('foo-' . $i), new EmptyIterator()));
+                $this->eventStore->create(new Stream(new StreamName('bar-' . $i), new EmptyIterator()));
+                $this->eventStore->create(new Stream(new StreamName('baz-' . $i), new EmptyIterator()));
+                $this->eventStore->create(new Stream(new StreamName('bam-' . $i), new EmptyIterator()));
+                $this->eventStore->create(new Stream(new StreamName('foobar-' . $i), new EmptyIterator()));
+                $this->eventStore->create(new Stream(new StreamName('foobaz-' . $i), new EmptyIterator()));
+                $this->eventStore->create(new Stream(new StreamName('foobam-' . $i), new EmptyIterator()));
             }
 
             for ($i = 0; $i < 20; $i++) {
                 $streamName = \uniqid('rand');
                 $streamNames[] = $streamName;
-                $this->eventStore->create(new Stream(new StreamName($streamName), new \EmptyIterator()));
+                $this->eventStore->create(new Stream(new StreamName($streamName), new EmptyIterator()));
             }
 
             $this->assertCount(7, $this->eventStore->fetchCategoryNames(null, 20, 0));
@@ -1122,9 +1062,7 @@ abstract class AbstractEventStoreTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_fetching_stream_categories_using_invalid_regex(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -1133,26 +1071,22 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->eventStore->fetchCategoryNamesRegex('invalid)', 10, 0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_given_invalid_metadata_value(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $value = new \stdClass();
+        $value = new stdClass();
         $value->foo = 'bar';
 
         $metadataMatcher = new MetadataMatcher();
         $metadataMatcher->withMetadataMatch('key', Operator::EQUALS(), $value);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_on_invalid_field_for_message_property(): void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
 
         $event = UserCreated::with(['name' => 'John'], 1);
         $event = $event->withAddedMetadata('foo', 'bar');
@@ -1177,7 +1111,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->eventStore->load($streamName, 1, null, $metadataMatcher->reveal());
     }
 
-    public function getMatchingMetadata(): array
+    public static function getMatchingMetadata(): array
     {
         return [
             [['snapshot' => true]],
@@ -1187,9 +1121,7 @@ abstract class AbstractEventStoreTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_return_stream_iterator_for_load(): void
     {
         $this->eventStore->create($this->getTestStream());
@@ -1197,9 +1129,7 @@ abstract class AbstractEventStoreTest extends TestCase
         $this->assertInstanceOf(StreamIterator::class, $this->eventStore->load(new StreamName('Prooph\Model\User')));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_return_stream_iterator_for_load_reversed(): void
     {
         $this->eventStore->create($this->getTestStream());

--- a/tests/ActionEventEmitterEventStoreTest.php
+++ b/tests/ActionEventEmitterEventStoreTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore;
 
 use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\ProophActionEventEmitter;
 use Prooph\EventStore\ActionEventEmitterEventStore;
@@ -27,14 +28,12 @@ use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\UsernameChanged;
 use Prophecy\PhpUnit\ProphecyTrait;
 
-class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestCase
+class ActionEventEmitterEventStoreTest extends AbstractActionEventEmitterEventStoreTestCase
 {
     use EventStoreTestStreamTrait;
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_breaks_loading_a_stream_when_listener_stops_propagation_but_does_not_provide_a_stream(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -54,9 +53,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->eventStore->load(new StreamName('Prooph\Model\User'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_cannot_create_a_stream_with_same_name_twice(): void
     {
         $this->expectException(StreamExistsAlready::class);
@@ -67,9 +64,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->eventStore->create($stream);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_append_to_non_existing_stream(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -77,12 +72,10 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $streamName = $this->prophesize(StreamName::class);
         $streamName->toString()->willReturn('test');
 
-        $this->eventStore->appendTo($streamName->reveal(), new \ArrayIterator());
+        $this->eventStore->appendTo($streamName->reveal(), new ArrayIterator());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_concurrency_exception_when_it_happens(): void
     {
         $this->expectException(ConcurrencyException::class);
@@ -100,9 +93,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $actionEventStore->appendTo($streamName, $events);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_load_non_existing_stream(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -113,9 +104,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->assertNull($this->eventStore->load($streamName->reveal()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_load_reverse_non_existing_stream(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -126,9 +115,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->assertNull($this->eventStore->loadReverse($streamName->reveal()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_loads_events_in_reverse_order(): void
     {
         $stream = $this->getTestStream();
@@ -173,9 +160,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->assertTrue($loadedEvents->current()->metadata()['snapshot']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_listener_stops_loading_events_and_does_not_provide_loaded_events(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -195,9 +180,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->eventStore->load($stream->streamName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_listener_stops_loading_events_and_does_not_provide_loaded_events_reverse(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -217,9 +200,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->eventStore->loadReverse($stream->streamName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_delete_unknown_stream(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -230,9 +211,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->eventStore->delete($streamName->reveal());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_append_events_when_listener_stops_propagation(): void
     {
         $recordedEvents = [];
@@ -240,7 +219,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->eventStore->attach(
             'create',
             function (ActionEvent $event) use (&$recordedEvents): void {
-                foreach ($event->getParam('recordedEvents', new \ArrayIterator()) as $recordedEvent) {
+                foreach ($event->getParam('recordedEvents', new ArrayIterator()) as $recordedEvent) {
                     $recordedEvents[] = $recordedEvent;
                 }
             },
@@ -250,7 +229,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->eventStore->attach(
             'appendTo',
             function (ActionEvent $event) use (&$recordedEvents): void {
-                foreach ($event->getParam('recordedEvents', new \ArrayIterator()) as $recordedEvent) {
+                foreach ($event->getParam('recordedEvents', new ArrayIterator()) as $recordedEvent) {
                     $recordedEvents[] = $recordedEvent;
                 }
             },
@@ -277,9 +256,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->assertCount(1, $this->eventStore->load(new StreamName('Prooph\Model\User')));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_uses_stream_provided_by_listener_when_listener_stops_propagation(): void
     {
         $stream = $this->getTestStream();
@@ -300,9 +277,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->assertCount(0, $emptyStream);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_listener_events_when_listener_stops_loading_events_and_provide_loaded_events(): void
     {
         $stream = $this->getTestStream();
@@ -346,9 +321,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->assertNotEquals($streamEventWithMetadata->uuid()->toString(), $loadedEvents->current()->uuid()->toString());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_appends_events_to_stream_and_records_them(): void
     {
         $recordedEvents = [];
@@ -368,7 +341,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->eventStore->attach(
             'appendTo',
             function (ActionEvent $event) use (&$recordedEvents): void {
-                foreach ($event->getParam('streamEvents', new \ArrayIterator()) as $recordedEvent) {
+                foreach ($event->getParam('streamEvents', new ArrayIterator()) as $recordedEvent) {
                     $recordedEvents[] = $recordedEvent;
                 }
             },
@@ -387,9 +360,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->assertCount(2, $recordedEvents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_a_new_stream_and_records_the_stream_events_and_deletes(): void
     {
         $recordedEvents = [];
@@ -432,9 +403,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->assertFalse($this->eventStore->hasStream($streamName));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_asked_for_unknown_stream_metadata(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -445,9 +414,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->eventStore->fetchStreamMetadata($streamName->reveal());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_asked_for_stream_metadata_and_event_gets_stopped(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -466,9 +433,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->eventStore->fetchStreamMetadata($streamName->reveal());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_updates_stream_metadata(): void
     {
         $stream = $this->getTestStream();
@@ -485,9 +450,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_stream_not_found_exception_when_trying_to_update_metadata_on_unknown_stream(): void
     {
         $this->expectException(StreamNotFound::class);
@@ -495,9 +458,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $this->eventStore->updateStreamMetadata(new StreamName('unknown'), []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_stream_names(): void
     {
         $eventStore = $this->prophesize(EventStore::class);
@@ -508,9 +469,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $wrapper->fetchStreamNames('foo', null, 10, 20);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_stream_names_regex(): void
     {
         $eventStore = $this->prophesize(EventStore::class);
@@ -521,9 +480,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $wrapper->fetchStreamNamesRegex('foo', null, 10, 20);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_category_names(): void
     {
         $eventStore = $this->prophesize(EventStore::class);
@@ -534,9 +491,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $wrapper->fetchCategoryNames('foo', 10, 20);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_category_names_regex(): void
     {
         $eventStore = $this->prophesize(EventStore::class);
@@ -547,9 +502,7 @@ class ActionEventEmitterEventStoreTest extends ActionEventEmitterEventStoreTestC
         $wrapper->fetchCategoryNamesRegex('foo', 10, 20);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_inner_event_store(): void
     {
         $eventStore = $this->prophesize(EventStore::class);

--- a/tests/Container/InMemoryEventStoreFactoryTest.php
+++ b/tests/Container/InMemoryEventStoreFactoryTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Container;
 
+use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Event\ActionEventEmitter;
 use Prooph\Common\Messaging\Message;
@@ -33,19 +35,18 @@ use ProophTest\EventStore\Mock\UsernameChanged;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
+use stdClass;
 
 class InMemoryEventStoreFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_event_store_with_default_event_emitter(): void
     {
         $config['prooph']['event_store']['default'] = [];
 
-        $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $containerMock->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
@@ -54,14 +55,12 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $this->assertInstanceOf(TransactionalActionEventEmitterEventStore::class, $eventStore);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_event_store_without_event_emitter(): void
     {
         $config['prooph']['event_store']['default'] = ['wrap_action_event_emitter' => false];
 
-        $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $containerMock->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
@@ -70,14 +69,12 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $this->assertInstanceOf(InMemoryEventStore::class, $eventStore);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_non_transactional_event_store_without_event_emitter(): void
     {
         $config['prooph']['event_store']['default'] = ['wrap_action_event_emitter' => false, 'transactional' => false];
 
-        $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $containerMock->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
@@ -86,14 +83,12 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $this->assertInstanceOf(NonTransactionalInMemoryEventStore::class, $eventStore);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_read_only_event_store(): void
     {
         $config['prooph']['event_store']['default'] = ['wrap_action_event_emitter' => false, 'read_only' => true];
 
-        $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $containerMock->method('get')->with('config')->willReturn($config);
 
         $factory = new InMemoryEventStoreFactory();
@@ -102,14 +97,12 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $this->assertInstanceOf(ReadOnlyEventStoreWrapper::class, $eventStore);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_event_store_with_default_event_emitter_via_callstatic(): void
     {
         $config['prooph']['event_store']['another'] = [];
 
-        $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $containerMock->method('get')->with('config')->willReturn($config);
 
         $type = 'another';
@@ -118,14 +111,12 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $this->assertInstanceOf(TransactionalActionEventEmitterEventStore::class, $eventStore);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_non_transactional_event_store_with_non_transactional_event_emitter_via_callstatic(): void
     {
         $config['prooph']['event_store']['another'] = ['transactional' => false];
 
-        $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $containerMock->method('get')->with('config')->willReturn($config);
 
         $type = 'another';
@@ -134,19 +125,21 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $this->assertInstanceOf(ActionEventEmitterEventStore::class, $eventStore);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_injects_custom_event_emitter(): void
     {
         $config['prooph']['event_store']['default']['event_emitter'] = 'event_emitter';
 
-        $eventEmitterMock = $this->getMockForAbstractClass(ActionEventEmitter::class);
+        $eventEmitterMock = $this->getMockBuilder(ActionEventEmitter::class)->getMock();
 
-        $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $containerMock->method('get')
-            ->withConsecutive(['config'], ['event_emitter'])
-            ->willReturnOnConsecutiveCalls($config, $eventEmitterMock);
+            ->willReturnCallback(function (string $value) use ($config, $eventEmitterMock) {
+                return match ($value) {
+                    'config' => $config,
+                    'event_emitter' => $eventEmitterMock,
+                };
+            });
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -154,9 +147,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $this->assertInstanceOf(TransactionalActionEventEmitterEventStore::class, $eventStore);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_injects_plugins(): void
     {
         $config['prooph']['event_store']['default']['plugins'][] = 'plugin';
@@ -164,10 +155,14 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $featureMock = $this->prophesize(Plugin::class);
         $featureMock->attachToEventStore(Argument::type(TransactionalActionEventEmitterEventStore::class))->shouldBeCalled();
 
-        $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $containerMock->method('get')
-            ->withConsecutive(['config'], ['plugin'])
-            ->willReturnOnConsecutiveCalls($config, $featureMock->reveal());
+            ->willReturnCallback(function (string $value) use ($config, $featureMock) {
+                return match ($value) {
+                    'config' => $config,
+                    'plugin' => $featureMock->reveal(),
+                };
+            });
 
         $factory = new InMemoryEventStoreFactory();
         $eventStore = $factory($containerMock);
@@ -175,9 +170,7 @@ class InMemoryEventStoreFactoryTest extends TestCase
         $this->assertInstanceOf(TransactionalActionEventEmitterEventStore::class, $eventStore);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_plugin_configured(): void
     {
         $this->expectException(ConfigurationException::class);
@@ -187,18 +180,20 @@ class InMemoryEventStoreFactoryTest extends TestCase
 
         $featureMock = 'foo';
 
-        $containerMock = $this->getMockForAbstractClass(ContainerInterface::class);
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $containerMock->method('get')
-            ->withConsecutive(['config'], ['plugin'])
-            ->willReturnOnConsecutiveCalls($config, $featureMock);
+            ->willReturnCallback(function (string $value) use ($config, $featureMock) {
+                return match ($value) {
+                    'config' => $config,
+                    'plugin' => $featureMock,
+                };
+            });
 
         $factory = new InMemoryEventStoreFactory();
         $factory($containerMock);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_injects_metadata_enrichers(): void
     {
         $config['prooph']['event_store']['default']['metadata_enrichers'][] = 'metadata_enricher1';
@@ -235,15 +230,13 @@ class InMemoryEventStoreFactoryTest extends TestCase
             ->shouldBeCalledTimes(\count($events))
             ->willReturnArgument(0);
 
-        $stream = new Stream(new StreamName('test'), new \ArrayIterator($events));
+        $stream = new Stream(new StreamName('test'), new ArrayIterator($events));
 
         // @var InMemoryEventStore $eventStore
         $eventStore->create($stream);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_metadata_enricher_configured(): void
     {
         $this->expectException(ConfigurationException::class);
@@ -253,15 +246,13 @@ class InMemoryEventStoreFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('config')->willReturn($config);
-        $container->get('foobar')->willReturn(new \stdClass());
+        $container->get('foobar')->willReturn(new stdClass());
 
         $factory = new InMemoryEventStoreFactory();
         $factory($container->reveal());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_container_given_to_callstatic(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Container/InMemoryProjectionManagerFactoryTest.php
+++ b/tests/Container/InMemoryProjectionManagerFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Container;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Container\InMemoryProjectionManagerFactory;
 use Prooph\EventStore\Exception\InvalidArgumentException;
@@ -25,9 +26,7 @@ class InMemoryProjectionManagerFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_projection_manager(): void
     {
         $config['prooph']['projection_manager']['default'] = [
@@ -46,9 +45,7 @@ class InMemoryProjectionManagerFactoryTest extends TestCase
         $this->assertInstanceOf(InMemoryProjectionManager::class, $projectionManager);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_projection_manager_via_callstatic(): void
     {
         $config['prooph']['projection_manager']['default'] = [
@@ -67,9 +64,7 @@ class InMemoryProjectionManagerFactoryTest extends TestCase
         $this->assertInstanceOf(InMemoryProjectionManager::class, $projectionManager);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_container_given_to_callstatic(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Example/QuickStartTest.php
+++ b/tests/Example/QuickStartTest.php
@@ -13,13 +13,12 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Example;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class QuickStartTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_provides_the_correct_example_output(): void
     {
         $pattern = \sprintf(

--- a/tests/InMemoryEventStoreTest.php
+++ b/tests/InMemoryEventStoreTest.php
@@ -15,15 +15,10 @@ namespace ProophTest\EventStore;
 
 use Prooph\EventStore\InMemoryEventStore;
 
-class InMemoryEventStoreTest extends AbstractEventStoreTest
+class InMemoryEventStoreTest extends AbstractEventStoreTestCase
 {
     use EventStoreTestStreamTrait;
     use TransactionalEventStoreTestTrait;
-
-    /**
-     * @var InMemoryEventStore
-     */
-    protected $eventStore;
 
     protected function setUp(): void
     {

--- a/tests/Metadata/MetadataEnricherAggregateTest.php
+++ b/tests/Metadata/MetadataEnricherAggregateTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Metadata;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\Exception\InvalidArgumentException;
@@ -21,14 +22,13 @@ use Prooph\EventStore\Metadata\MetadataEnricherAggregate;
 use ProophTest\EventStore\Mock\TestDomainEvent;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use stdClass;
 
 class MetadataEnricherAggregateTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_aggregates_metadata_enrichers(): void
     {
         // Mocks
@@ -69,16 +69,14 @@ class MetadataEnricherAggregateTest extends TestCase
         $this->assertEquals($expectedMetadata, $enrichedEvent->metadata());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_only_accept_correct_instances(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         new MetadataEnricherAggregate([
             $this->prophesize(MetadataEnricher::class)->reveal(),
-            new \stdClass(),
+            new stdClass(),
             $this->prophesize(MetadataEnricher::class)->reveal(),
         ]);
     }

--- a/tests/Metadata/MetadataEnricherPluginTest.php
+++ b/tests/Metadata/MetadataEnricherPluginTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Metadata;
 
+use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Event\DefaultActionEvent;
 use Prooph\Common\Event\ProophActionEventEmitter;
@@ -31,9 +33,7 @@ class MetadataEnricherPluginTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_enrich_metadata_on_stream_create(): void
     {
         $metadataEnricher = new class() implements MetadataEnricher {
@@ -48,7 +48,7 @@ class MetadataEnricherPluginTest extends TestCase
         $plugin = new MetadataEnricherPlugin($metadataEnricher);
         $plugin->attachToEventStore($eventStore);
 
-        $eventStore->create(new Stream(new StreamName('foo'), new \ArrayIterator([new TestDomainEvent(['foo' => 'bar'])])));
+        $eventStore->create(new Stream(new StreamName('foo'), new ArrayIterator([new TestDomainEvent(['foo' => 'bar'])])));
 
         $streamEvents = $eventStore->load(new StreamName('foo'));
 
@@ -58,9 +58,7 @@ class MetadataEnricherPluginTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_enrich_metadata_on_create_if_stream_is_not_set(): void
     {
         $metadataEnricher = $this->prophesize(MetadataEnricher::class);
@@ -72,9 +70,7 @@ class MetadataEnricherPluginTest extends TestCase
         $plugin->onEventStoreCreateStream($actionEvent);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_enrich_metadata_on_stream_appendTo(): void
     {
         $metadataEnricher = new class() implements MetadataEnricher {
@@ -86,12 +82,12 @@ class MetadataEnricherPluginTest extends TestCase
 
         $eventStore = new ActionEventEmitterEventStore(new InMemoryEventStore(), new ProophActionEventEmitter());
 
-        $eventStore->create(new Stream(new StreamName('foo'), new \ArrayIterator()));
+        $eventStore->create(new Stream(new StreamName('foo'), new ArrayIterator()));
 
         $plugin = new MetadataEnricherPlugin($metadataEnricher);
         $plugin->attachToEventStore($eventStore);
 
-        $eventStore->appendTo(new StreamName('foo'), new \ArrayIterator([new TestDomainEvent(['foo' => 'bar'])]));
+        $eventStore->appendTo(new StreamName('foo'), new ArrayIterator([new TestDomainEvent(['foo' => 'bar'])]));
 
         $streamEvents = $eventStore->load(new StreamName('foo'));
 
@@ -101,9 +97,7 @@ class MetadataEnricherPluginTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_enrich_metadata_on_appendTo_if_stream_is_not_set(): void
     {
         $metadataEnricher = $this->prophesize(MetadataEnricher::class);
@@ -115,9 +109,7 @@ class MetadataEnricherPluginTest extends TestCase
         $plugin->onEventStoreAppendToStream($actionEvent);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_detaches_from_event_store(): void
     {
         $metadataEnricher = $this->prophesize(MetadataEnricher::class);
@@ -129,7 +121,7 @@ class MetadataEnricherPluginTest extends TestCase
         $plugin->attachToEventStore($eventStore);
         $plugin->detachFromEventStore($eventStore);
 
-        $eventStore->create(new Stream(new StreamName('foo'), new \ArrayIterator([new TestDomainEvent(['foo' => 'bar'])])));
+        $eventStore->create(new Stream(new StreamName('foo'), new ArrayIterator([new TestDomainEvent(['foo' => 'bar'])])));
 
         $stream = $eventStore->load(new StreamName('foo'));
 

--- a/tests/Metadata/MetadataMatcherTest.php
+++ b/tests/Metadata/MetadataMatcherTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Metadata;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Exception\InvalidArgumentException;
 use Prooph\EventStore\Metadata\FieldType;
@@ -21,9 +22,7 @@ use Prooph\EventStore\Metadata\Operator;
 
 class MetadataMatcherTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_on_invalid_value_for_in_operator(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -33,9 +32,7 @@ class MetadataMatcherTest extends TestCase
         $metadataMatcher->withMetadataMatch('foo', Operator::IN(), 'bar', FieldType::METADATA());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_on_invalid_value_for_not_in_operator(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -45,9 +42,7 @@ class MetadataMatcherTest extends TestCase
         $metadataMatcher->withMetadataMatch('foo', Operator::NOT_IN(), 'bar', FieldType::METADATA());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_on_invalid_value_for_regex_operator(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -57,9 +52,7 @@ class MetadataMatcherTest extends TestCase
         $metadataMatcher->withMetadataMatch('foo', Operator::REGEX(), false, FieldType::METADATA());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_on_invalid_value_for_equals_operator(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Mock/Post.php
+++ b/tests/Mock/Post.php
@@ -28,7 +28,7 @@ class Post
     private string $email;
 
     /**
-     * @var DomainEvent[]|null
+     * @var list<DomainEvent>|null
      */
     private ?array $recordedEvents = null;
 
@@ -51,7 +51,7 @@ class Post
     }
 
     /**
-     * @param DomainEvent[] $historyEvents
+     * @param list<DomainEvent> $historyEvents
      * @return Post
      */
     public static function reconstituteFromHistory(array $historyEvents): Post
@@ -67,7 +67,7 @@ class Post
     {
     }
 
-    public function getId(): Uuid
+    public function getId(): UuidInterface
     {
         return $this->postId;
     }
@@ -77,13 +77,13 @@ class Post
         return $this->text;
     }
 
-    private function recordThat(TestDomainEvent $domainEvent): void
+    private function recordThat(DomainEvent $domainEvent): void
     {
         $this->recordedEvents[] = $domainEvent;
         $this->apply($domainEvent);
     }
 
-    public function apply(TestDomainEvent $event): void
+    public function apply(DomainEvent $event): void
     {
         if ($event instanceof PostCreated) {
             $this->whenPostCreated($event);
@@ -109,7 +109,7 @@ class Post
     }
 
     /**
-     * @param DomainEvent[] $streamEvents
+     * @param list<DomainEvent> $streamEvents
      */
     private function replay(array $streamEvents): void
     {

--- a/tests/NonTransactionalInMemoryEventStoreTest.php
+++ b/tests/NonTransactionalInMemoryEventStoreTest.php
@@ -13,17 +13,11 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore;
 
-use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\NonTransactionalInMemoryEventStore;
 
-class NonTransactionalInMemoryEventStoreTest extends AbstractEventStoreTest
+class NonTransactionalInMemoryEventStoreTest extends AbstractEventStoreTestCase
 {
     use EventStoreTestStreamTrait;
-
-    /**
-     * @var InMemoryEventStore
-     */
-    protected $eventStore;
 
     protected function setUp(): void
     {

--- a/tests/Plugin/PluginManagerTest.php
+++ b/tests/Plugin/PluginManagerTest.php
@@ -13,21 +13,21 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Plugin;
 
+use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
-use ProophTest\EventStore\ActionEventEmitterEventStoreTestCase;
+use ProophTest\EventStore\AbstractActionEventEmitterEventStoreTestCase;
 use ProophTest\EventStore\Mock\EventLoggerPlugin;
 use ProophTest\EventStore\Mock\UserCreated;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
-class PluginManagerTest extends ActionEventEmitterEventStoreTestCase
+class PluginManagerTest extends AbstractActionEventEmitterEventStoreTestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function an_invokable_plugin_is_loaded_by_plugin_manager_and_attached_to_event_store_by_configuration(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
@@ -40,7 +40,7 @@ class PluginManagerTest extends ActionEventEmitterEventStoreTestCase
         $this->eventStore->create(
             new Stream(
                 new StreamName('user'),
-                new \ArrayIterator([
+                new ArrayIterator([
                     UserCreated::with(
                         [
                             'name' => 'Alex',

--- a/tests/Plugin/UpcastingPluginTest.php
+++ b/tests/Plugin/UpcastingPluginTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Plugin;
 
+use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\Exception\StreamNotFound;
 use Prooph\EventStore\Plugin\UpcastingPlugin;
@@ -20,15 +22,13 @@ use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use Prooph\EventStore\Upcasting\NoOpEventUpcaster;
 use Prooph\EventStore\Upcasting\SingleEventUpcaster;
-use ProophTest\EventStore\ActionEventEmitterEventStoreTestCase;
+use ProophTest\EventStore\AbstractActionEventEmitterEventStoreTestCase;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
 
-class UpcastingPluginTest extends ActionEventEmitterEventStoreTestCase
+class UpcastingPluginTest extends AbstractActionEventEmitterEventStoreTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_attaches_to_event_store(): void
     {
         $upcaster = new class() extends SingleEventUpcaster {
@@ -51,7 +51,7 @@ class UpcastingPluginTest extends ActionEventEmitterEventStoreTestCase
         $this->eventStore->create(
             new Stream(
                 $streamName,
-                new \ArrayIterator([
+                new ArrayIterator([
                     UserCreated::with(
                         [
                             'name' => 'Alex',
@@ -86,9 +86,7 @@ class UpcastingPluginTest extends ActionEventEmitterEventStoreTestCase
         $this->assertEquals(['key' => 'value', '_aggregate_version' => 1], $iterator->current()->metadata());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_ignores_when_no_iterator_in_result(): void
     {
         $this->expectException(StreamNotFound::class);

--- a/tests/Projection/AbstractEventStoreProjectorTestCase.php
+++ b/tests/Projection/AbstractEventStoreProjectorTestCase.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Projection;
 
 use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
@@ -33,23 +34,13 @@ use ProophTest\EventStore\Mock\UsernameChanged;
 /**
  * Common tests for all event store projector implementations
  */
-abstract class AbstractEventStoreProjectorTest extends TestCase
+abstract class AbstractEventStoreProjectorTestCase extends TestCase
 {
-    /**
-     * @var ProjectionManager
-     */
-    protected $projectionManager;
+    protected ProjectionManager $projectionManager;
 
-    /**
-     * @var EventStore
-     */
-    protected $eventStore;
+    protected EventStore $eventStore;
 
-    /**
-     * @test
-     *
-     * This tests works because this projection does not handle the first event in the stream.
-     */
+    #[Test]
     public function it_persists_after_blocksize_processed_events_for_multiple_handlers(): void
     {
         $this->prepareEventStream('user-123');
@@ -108,9 +99,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $testCase->assertSame(50, $position, \sprintf("finally the persisted position expectation is '%s'", 50));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_project_from_stream_and_reset(): void
     {
         $this->prepareEventStream('user-123');
@@ -154,9 +143,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_be_stopped_while_processing(): void
     {
         $this->prepareEventStream('user-123');
@@ -182,9 +169,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(10, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_streams(): void
     {
         $this->prepareEventStream('user-123');
@@ -209,9 +194,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(100, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_stream_and_filter_with_metadata_matcher(): void
     {
         $this->prepareEventStream('user-123');
@@ -240,9 +223,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(10, $projection->getState()['version']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_all_ignoring_internal_streams(): void
     {
         $this->prepareEventStream('user-123');
@@ -275,9 +256,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(100, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_category_with_when_any(): void
     {
         $this->prepareEventStream('user-123');
@@ -302,9 +281,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(100, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_categories_with_when(): void
     {
         $this->prepareEventStream('user-123');
@@ -331,9 +308,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(4, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resumes_projection_from_position(): void
     {
         $this->prepareEventStream('user-123');
@@ -372,9 +347,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(148, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_ignores_error_on_delete_of_not_created_stream_projections(): void
     {
         $this->prepareEventStream('user-123');
@@ -397,12 +370,10 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEmpty($this->projectionManager->fetchProjectionNames('test-projection'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_run_two_projections_at_the_same_time(): void
     {
-        $this->expectException(\Prooph\EventStore\Exception\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Another projection process is already running');
 
         $this->prepareEventStream('user-123');
@@ -432,9 +403,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
             ->run();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_before_start_when_it_was_deleted_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -477,9 +446,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(49, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_incl_emitting_events_before_start_when_it_was_deleted_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -522,9 +489,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(49, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_during_run_when_it_was_deleted_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -564,9 +529,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals([], $projectionManager->fetchProjectionNames('test_projection'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_incl_emitted_events_during_run_when_it_was_deleted_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -606,9 +569,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals([], $projectionManager->fetchProjectionNames('test_projection'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resets_projection_before_start_when_it_was_reset_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -649,9 +610,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(148, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resets_projection_during_run_when_it_was_reset_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -690,9 +649,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(98, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_stops_when_projection_before_start_when_it_was_stopped_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -733,9 +690,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(49, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_stops_projection_during_run_when_it_was_stopped_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -774,9 +729,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(49, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resets_to_empty_array(): void
     {
         $projection = $this->projectionManager->createProjection('test_projection');
@@ -792,9 +745,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertIsArray($state2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_init_callback_provided_twice(): void
     {
         $this->expectException(RuntimeException::class);
@@ -809,9 +760,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice(): void
     {
         $this->expectException(RuntimeException::class);
@@ -822,9 +771,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $projection->fromStream('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_2(): void
     {
         $this->expectException(RuntimeException::class);
@@ -835,9 +782,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $projection->fromCategory('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_3(): void
     {
         $this->expectException(RuntimeException::class);
@@ -848,9 +793,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $projection->fromStreams('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_4(): void
     {
         $this->expectException(RuntimeException::class);
@@ -861,9 +804,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $projection->fromCategories('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_5(): void
     {
         $this->expectException(RuntimeException::class);
@@ -874,9 +815,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $projection->fromAll('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_when_called_twice_(): void
     {
         $this->expectException(RuntimeException::class);
@@ -889,9 +828,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         }]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_handlers_configured(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -902,9 +839,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         }]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_handlers_configured_2(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -914,9 +849,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $projection->when(['foo' => 'invalid']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_whenAny_called_twice(): void
     {
         $this->expectException(RuntimeException::class);
@@ -929,9 +862,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_on_run_when_nothing_configured(): void
     {
         $this->expectException(RuntimeException::class);
@@ -940,9 +871,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $projection->run();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_links_to_and_loads_and_continues_again(): void
     {
         $this->prepareEventStream('user-123');
@@ -989,9 +918,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertCount(100, $events);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_emits_events_and_resets(): void
     {
         $this->prepareEventStream('user-123');
@@ -1022,9 +949,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->eventStore->load(new StreamName('test_projection'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_emits_events_and_deletes(): void
     {
         $this->prepareEventStream('user-123');
@@ -1052,9 +977,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->eventStore->load(new StreamName('test_projection'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_persists_in_single_handler(): void
     {
         $this->prepareEventStream('user-123');
@@ -1076,9 +999,7 @@ abstract class AbstractEventStoreProjectorTest extends TestCase
         $this->assertEquals(50, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_persists_in_handlers(): void
     {
         $this->prepareEventStream('user-123');

--- a/tests/Projection/AbstractEventStoreQueryTestCase.php
+++ b/tests/Projection/AbstractEventStoreQueryTestCase.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Projection;
 
 use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
@@ -30,21 +31,13 @@ use ProophTest\EventStore\Mock\UsernameChanged;
 /**
  * Common tests for all event store query implementations
  */
-abstract class AbstractEventStoreQueryTest extends TestCase
+abstract class AbstractEventStoreQueryTestCase extends TestCase
 {
-    /**
-     * @var ProjectionManager
-     */
-    protected $projectionManager;
+    protected ProjectionManager $projectionManager;
 
-    /**
-     * @var EventStore
-     */
-    protected $eventStore;
+    protected EventStore $eventStore;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_stream_and_reset(): void
     {
         $this->prepareEventStream('user-123');
@@ -74,9 +67,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $this->assertEquals(49, $query->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_be_stopped_while_processing(): void
     {
         $this->prepareEventStream('user-123');
@@ -102,9 +93,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $this->assertEquals(10, $query->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_streams(): void
     {
         $this->prepareEventStream('user-123');
@@ -129,9 +118,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $this->assertEquals(100, $query->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_stream_and_filter_with_metadata_matcher(): void
     {
         $this->prepareEventStream('user-123');
@@ -159,9 +146,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $this->assertEquals(10, $projection->getState()['version']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_all_ignoring_internal_streams(): void
     {
         $this->prepareEventStream('user-123');
@@ -194,9 +179,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $this->assertEquals(100, $query->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_category_with_when_any(): void
     {
         $this->prepareEventStream('user-123');
@@ -221,9 +204,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $this->assertEquals(100, $query->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_categories_with_when(): void
     {
         $this->prepareEventStream('user-123');
@@ -250,9 +231,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $this->assertEquals(4, $query->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resumes_query_from_position(): void
     {
         $this->prepareEventStream('user-123');
@@ -291,9 +270,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $this->assertEquals(148, $query->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resets_to_empty_array(): void
     {
         $query = $this->projectionManager->createQuery();
@@ -309,9 +286,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $this->assertIsArray($state2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_init_callback_provided_twice(): void
     {
         $this->expectException(RuntimeException::class);
@@ -326,9 +301,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice(): void
     {
         $this->expectException(RuntimeException::class);
@@ -339,9 +312,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $query->fromStream('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_2(): void
     {
         $this->expectException(RuntimeException::class);
@@ -352,9 +323,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $query->fromCategory('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_3(): void
     {
         $this->expectException(RuntimeException::class);
@@ -365,9 +334,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $query->fromStreams('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_4(): void
     {
         $this->expectException(RuntimeException::class);
@@ -378,9 +345,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $query->fromCategories('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_5(): void
     {
         $this->expectException(RuntimeException::class);
@@ -391,9 +356,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $query->fromAll('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_when_called_twice(): void
     {
         $this->expectException(RuntimeException::class);
@@ -406,9 +369,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         }]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_handlers_configured(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -419,9 +380,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         }]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_handlers_configured_2(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -431,9 +390,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         $query->when(['foo' => 'invalid']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_whenAny_called_twice(): void
     {
         $this->expectException(RuntimeException::class);
@@ -446,9 +403,7 @@ abstract class AbstractEventStoreQueryTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_on_run_when_nothing_configured(): void
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Projection/AbstractEventStoreReadModelProjectorTestCase.php
+++ b/tests/Projection/AbstractEventStoreReadModelProjectorTestCase.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Projection;
 
 use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
@@ -34,25 +35,15 @@ use Prophecy\PhpUnit\ProphecyTrait;
 /**
  * Common tests for all event store read model projector implementations
  */
-abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
+abstract class AbstractEventStoreReadModelProjectorTestCase extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ProjectionManager
-     */
-    protected $projectionManager;
+    protected ProjectionManager $projectionManager;
 
-    /**
-     * @var EventStore
-     */
-    protected $eventStore;
+    protected EventStore $eventStore;
 
-    /**
-     * @test
-     *
-     * This tests works because this projection does not handle the first event in the stream.
-     */
+    #[Test]
     public function it_persists_after_blocksize_processed_events_for_multiple_handlers(): void
     {
         $this->prepareEventStream('user-123');
@@ -112,9 +103,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $testCase->assertSame(50, $position, \sprintf("finally the persisted position expectation is '%s'", 50));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_project_from_stream_and_reset(): void
     {
         $this->prepareEventStream('user-123');
@@ -150,9 +139,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(49, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_project_from_stream_and_delete(): void
     {
         $this->prepareEventStream('user-123');
@@ -184,9 +171,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertFalse($readModel->isInitialized());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_be_stopped_while_processing(): void
     {
         $this->prepareEventStream('user-123');
@@ -214,9 +199,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(10, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_streams(): void
     {
         $this->prepareEventStream('user-123');
@@ -243,9 +226,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(100, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_stream_and_filter_with_metadata_matcher(): void
     {
         $this->prepareEventStream('user-123');
@@ -276,9 +257,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(10, $projection->getState()['version']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_all_ignoring_internal_streams(): void
     {
         $this->prepareEventStream('user-123');
@@ -313,9 +292,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(100, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_category_with_when_any(): void
     {
         $this->prepareEventStream('user-123');
@@ -342,9 +319,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(100, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_query_from_categories_with_when(): void
     {
         $this->prepareEventStream('user-123');
@@ -373,9 +348,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(4, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resumes_projection_from_position(): void
     {
         $this->prepareEventStream('user-123');
@@ -416,9 +389,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(148, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resets_to_empty_array(): void
     {
         $readModel = new ReadModelMock();
@@ -436,9 +407,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertIsArray($state2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_init_callback_provided_twice(): void
     {
         $this->expectException(RuntimeException::class);
@@ -455,9 +424,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice(): void
     {
         $this->expectException(RuntimeException::class);
@@ -470,9 +437,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $projection->fromStream('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_2(): void
     {
         $this->expectException(RuntimeException::class);
@@ -485,9 +450,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $projection->fromCategory('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_3(): void
     {
         $this->expectException(RuntimeException::class);
@@ -500,9 +463,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $projection->fromStreams('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_4(): void
     {
         $this->expectException(RuntimeException::class);
@@ -515,9 +476,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $projection->fromCategories('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_from_called_twice_5(): void
     {
         $this->expectException(RuntimeException::class);
@@ -530,9 +489,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $projection->fromAll('bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_when_called_twice_(): void
     {
         $this->expectException(RuntimeException::class);
@@ -547,9 +504,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         }]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_handlers_configured(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -562,9 +517,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         }]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_handlers_configured_2(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -576,9 +529,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $projection->when(['foo' => 'invalid']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_whenAny_called_twice(): void
     {
         $this->expectException(RuntimeException::class);
@@ -593,9 +544,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_on_run_when_nothing_configured(): void
     {
         $this->expectException(RuntimeException::class);
@@ -606,9 +555,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $projection->run();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_updates_read_model_using_when(): void
     {
         $this->prepareEventStream('user-123');
@@ -644,9 +591,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertFalse($readModel->hasKey('name'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_updates_read_model_using_when_any(): void
     {
         $this->prepareEventStream('user-123');
@@ -672,12 +617,10 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals('Sascha', $readModel->read('name'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_run_two_projections_at_the_same_time(): void
     {
-        $this->expectException(\Prooph\EventStore\Exception\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Another projection process is already running');
 
         $this->prepareEventStream('user-123');
@@ -703,9 +646,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
             ->run();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_updates_projection_and_deletes(): void
     {
         $this->prepareEventStream('user-123');
@@ -733,9 +674,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertFalse($readModel->isInitialized());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_persists_using_single_handler(): void
     {
         $this->prepareEventStream('user-123');
@@ -761,9 +700,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(50, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_persists_in_handlers(): void
     {
         $this->prepareEventStream('user-123');
@@ -791,9 +728,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(49, $projection->getState()['count']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_before_start_when_it_was_deleted_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -834,9 +769,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(49, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_incl_emitted_events_before_start_when_it_was_deleted_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -877,9 +810,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(49, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_during_run_when_it_was_deleted_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -916,9 +847,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals([], $projectionManager->fetchProjectionNames('test_projection'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_incl_emitted_events_during_run_when_it_was_deleted_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -955,9 +884,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals([], $projectionManager->fetchProjectionNames('test_projection'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resets_projection_before_start_when_it_was_reset_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -998,9 +925,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(148, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resets_projection_during_run_when_it_was_reset_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -1038,9 +963,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(98, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_stops_when_projection_before_start_when_it_was_stopped_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -1081,9 +1004,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(49, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_stops_projection_during_run_when_it_was_stopped_from_outside(): void
     {
         $this->prepareEventStream('user-123');
@@ -1121,9 +1042,7 @@ abstract class AbstractEventStoreReadModelProjectorTest extends TestCase
         $this->assertEquals(49, $calledTimes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_calls_reset_projection_also_if_init_callback_returns_state(): void
     {
         $readModel = $this->prophesize(ReadModel::class);

--- a/tests/Projection/AbstractProjectionManagerTestCase.php
+++ b/tests/Projection/AbstractProjectionManagerTestCase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Projection;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Exception\InvalidArgumentException;
 use Prooph\EventStore\Exception\OutOfRangeException;
@@ -23,17 +24,11 @@ use Prooph\EventStore\Projection\ProjectionStatus;
 /**
  * Common tests for all projection manager implementations
  */
-abstract class AbstractProjectionManagerTest extends TestCase
+abstract class AbstractProjectionManagerTestCase extends TestCase
 {
-    /**
-     * @var ProjectionManager
-     */
-    protected $projectionManager;
+    protected ProjectionManager $projectionManager;
 
-    /**
-     * @test
-     * @medium
-     */
+    #[Test]
     public function it_fetches_projection_names(): void
     {
         $projections = [];
@@ -73,9 +68,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_projection_names_with_filter(): void
     {
         $projection = $this->projectionManager->createProjection('user-1');
@@ -103,9 +96,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->assertSame([], $this->projectionManager->fetchProjectionNames('foo', 10, 100));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_projection_names_sorted(): void
     {
         $projection = $this->projectionManager->createProjection('user-100');
@@ -134,9 +125,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_fetching_projection_names_using_invalid_limit(): void
     {
         $this->expectException(OutOfRangeException::class);
@@ -145,9 +134,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->projectionManager->fetchProjectionNames(null, -1, 0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_fetching_projection_names_using_invalid_offset(): void
     {
         $this->expectException(OutOfRangeException::class);
@@ -156,10 +143,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->projectionManager->fetchProjectionNames(null, 1, -1);
     }
 
-    /**
-     * @test
-     * @medium
-     */
+    #[Test]
     public function it_fetches_projection_names_using_regex(): void
     {
         for ($i = 0; $i < 50; $i++) {
@@ -181,9 +165,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->assertCount(5, $this->projectionManager->fetchProjectionNamesRegex('rand', 100, 15));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_projection_names_sorted_using_regex(): void
     {
         $projection = $this->projectionManager->createProjection('user-100');
@@ -212,9 +194,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_fetching_projection_names_using_regex_with_invalid_limit(): void
     {
         $this->expectException(OutOfRangeException::class);
@@ -223,9 +203,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->projectionManager->fetchProjectionNamesRegex('foo', -1, 0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_fetching_projection_names_using_regex_with_invalid_offset(): void
     {
         $this->expectException(OutOfRangeException::class);
@@ -234,9 +212,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->projectionManager->fetchProjectionNamesRegex('bar', 1, -1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_fetching_projection_names_using_invalid_regex(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -245,9 +221,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->projectionManager->fetchProjectionNamesRegex('invalid)', 10, 0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_asked_for_unknown_projection_status(): void
     {
         $this->expectException(ProjectionNotFound::class);
@@ -255,9 +229,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->projectionManager->fetchProjectionStatus('unkown');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_asked_for_unknown_projection_stream_positions(): void
     {
         $this->expectException(ProjectionNotFound::class);
@@ -265,9 +237,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->projectionManager->fetchProjectionStreamPositions('unkown');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_asked_for_unknown_projection_state(): void
     {
         $this->expectException(ProjectionNotFound::class);
@@ -275,9 +245,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->projectionManager->fetchProjectionState('unkown');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_projection_status(): void
     {
         $projection = $this->projectionManager->createProjection('test-projection');
@@ -287,9 +255,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->assertSame(ProjectionStatus::IDLE(), $this->projectionManager->fetchProjectionStatus('test-projection'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_projection_stream_positions(): void
     {
         $projection = $this->projectionManager->createProjection('test-projection');
@@ -299,9 +265,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->assertSame([], $this->projectionManager->fetchProjectionStreamPositions('test-projection'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fetches_projection_state(): void
     {
         $projection = $this->projectionManager->createProjection('test-projection');
@@ -311,9 +275,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->assertSame([], $this->projectionManager->fetchProjectionState('test-projection'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_delete_non_existing_projection(): void
     {
         $this->expectException(ProjectionNotFound::class);
@@ -321,9 +283,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->projectionManager->deleteProjection('unknown', false);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_reset_non_existing_projection(): void
     {
         $this->expectException(ProjectionNotFound::class);
@@ -331,9 +291,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->projectionManager->resetProjection('unknown');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_stop_non_existing_projection(): void
     {
         $this->expectException(ProjectionNotFound::class);
@@ -341,9 +299,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->projectionManager->stopProjection('unknown');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_fail_deleting_twice(): void
     {
         $projection = $this->projectionManager->createProjection('test-projection');
@@ -356,9 +312,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->assertTrue($this->projectionManager->fetchProjectionStatus('test-projection')->is(ProjectionStatus::DELETING()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_fail_resetting_twice(): void
     {
         $projection = $this->projectionManager->createProjection('test-projection');
@@ -371,9 +325,7 @@ abstract class AbstractProjectionManagerTest extends TestCase
         $this->assertTrue($this->projectionManager->fetchProjectionStatus('test-projection')->is(ProjectionStatus::RESETTING()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_fail_stopping_twice(): void
     {
         $projection = $this->projectionManager->createProjection('test-projection');

--- a/tests/Projection/InMemoryEventStoreProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Projection;
 
+use PHPUnit\Framework\Attributes\Test;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception\InvalidArgumentException;
@@ -22,19 +23,9 @@ use Prooph\EventStore\Projection\InMemoryEventStoreProjector;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
 use Prophecy\PhpUnit\ProphecyTrait;
 
-class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
+class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTestCase
 {
     use ProphecyTrait;
-
-    /**
-     * @var InMemoryProjectionManager
-     */
-    protected $projectionManager;
-
-    /**
-     * @var InMemoryEventStore
-     */
-    protected $eventStore;
 
     protected function setUp(): void
     {
@@ -42,89 +33,67 @@ class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
         $this->projectionManager = new InMemoryProjectionManager($this->eventStore);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_persists_after_blocksize_processed_events_for_multiple_handlers(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager does not honor blocksize');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_run_two_projections_at_the_same_time(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot guard against concurrent projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_during_run_when_it_was_deleted_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_before_start_when_it_was_deleted_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_incl_emitting_events_before_start_when_it_was_deleted_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_incl_emitted_events_during_run_when_it_was_deleted_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resets_projection_before_start_when_it_was_reset_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot reset projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resets_projection_during_run_when_it_was_reset_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot reset projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_stops_when_projection_before_start_when_it_was_stopped_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot stop projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_stops_projection_during_run_when_it_was_stopped_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot stop projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_unknown_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -134,9 +103,7 @@ class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
         new InMemoryEventStoreProjector($eventStore->reveal(), 'test_projection', 10, 10);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_wrapped_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -148,9 +115,7 @@ class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
         new InMemoryEventStoreProjector($wrappedEventStore->reveal(), 'test_projection', 1, 1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_allows_non_transactional_event_store_instance(): void
     {
         $eventStore = new NonTransactionalInMemoryEventStore();
@@ -159,9 +124,7 @@ class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
         $this->assertInstanceOf(InMemoryEventStoreProjector::class, $projector);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_cache_size_given(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -169,9 +132,7 @@ class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
         new InMemoryEventStoreProjector($this->eventStore, 'test_projection', -1, 1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_sleep_given(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -179,10 +140,7 @@ class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
         new InMemoryEventStoreProjector($this->eventStore, 'test_projection', 1, -1);
     }
 
-    /**
-     * @test
-     * @medium
-     */
+    #[Test]
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {
         if (! \extension_loaded('pcntl')) {
@@ -214,10 +172,7 @@ class InMemoryEventStoreProjectorTest extends AbstractEventStoreProjectorTest
         );
     }
 
-    /**
-     * @test
-     * @small
-     */
+    #[Test]
     public function it_stops_immediately_after_pcntl_signal_was_received(): void
     {
         if (! \extension_loaded('pcntl')) {

--- a/tests/Projection/InMemoryEventStoreQueryTest.php
+++ b/tests/Projection/InMemoryEventStoreQueryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Projection;
 
+use PHPUnit\Framework\Attributes\Test;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception\InvalidArgumentException;
@@ -22,19 +23,9 @@ use Prooph\EventStore\Projection\InMemoryEventStoreQuery;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
 use Prophecy\PhpUnit\ProphecyTrait;
 
-class InMemoryEventStoreQueryTest extends AbstractEventStoreQueryTest
+class InMemoryEventStoreQueryTest extends AbstractEventStoreQueryTestCase
 {
     use ProphecyTrait;
-
-    /**
-     * @var InMemoryProjectionManager
-     */
-    protected $projectionManager;
-
-    /**
-     * @var InMemoryEventStore
-     */
-    protected $eventStore;
 
     protected function setUp(): void
     {
@@ -42,9 +33,7 @@ class InMemoryEventStoreQueryTest extends AbstractEventStoreQueryTest
         $this->projectionManager = new InMemoryProjectionManager($this->eventStore);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_unknown_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -54,9 +43,7 @@ class InMemoryEventStoreQueryTest extends AbstractEventStoreQueryTest
         new InMemoryEventStoreQuery($eventStore->reveal());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_wrapped_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -68,9 +55,7 @@ class InMemoryEventStoreQueryTest extends AbstractEventStoreQueryTest
         new InMemoryEventStoreQuery($wrappedEventStore->reveal());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_allows_non_transactional_event_store_instance(): void
     {
         $eventStore = new NonTransactionalInMemoryEventStore();
@@ -79,10 +64,7 @@ class InMemoryEventStoreQueryTest extends AbstractEventStoreQueryTest
         $this->assertInstanceOf(InMemoryEventStoreQuery::class, $query);
     }
 
-    /**
-     * @test
-     * @small
-     */
+    #[Test]
     public function it_stops_immediately_after_pcntl_signal_was_received(): void
     {
         if (! \extension_loaded('pcntl')) {

--- a/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Projection;
 
+use PHPUnit\Framework\Attributes\Test;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception\InvalidArgumentException;
@@ -22,107 +23,75 @@ use Prooph\EventStore\Projection\InMemoryEventStoreReadModelProjector;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
 use ProophTest\EventStore\Mock\ReadModelMock;
 
-class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadModelProjectorTest
+class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadModelProjectorTestCase
 {
-    /**
-     * @var InMemoryProjectionManager
-     */
-    protected $projectionManager;
-
-    /**
-     * @var InMemoryEventStore
-     */
-    protected $eventStore;
-
     protected function setUp(): void
     {
         $this->eventStore = new InMemoryEventStore();
         $this->projectionManager = new InMemoryProjectionManager($this->eventStore);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_persists_after_blocksize_processed_events_for_multiple_handlers(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager does not honor blocksize');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_run_two_projections_at_the_same_time(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot guard agains concurrent projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_during_run_when_it_was_deleted_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_before_start_when_it_was_deleted_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_incl_emitted_events_before_start_when_it_was_deleted_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_deletes_projection_incl_emitted_events_during_run_when_it_was_deleted_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot delete projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resets_projection_before_start_when_it_was_reset_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot reset projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_resets_projection_during_run_when_it_was_reset_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot reset projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_stops_when_projection_before_start_when_it_was_stopped_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot stop projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_stops_projection_during_run_when_it_was_stopped_from_outside(): void
     {
         $this->markTestSkipped('InMemoryProjectionManager cannot stop projections');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_cache_size_given(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -130,9 +99,7 @@ class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadMod
         new InMemoryEventStoreReadModelProjector($this->eventStore, 'test_projection', new ReadModelMock(), -1, 1, 1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_persist_block_size_given(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -140,9 +107,7 @@ class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadMod
         new InMemoryEventStoreReadModelProjector($this->eventStore, 'test_projection', new ReadModelMock(), 1, -1, 25);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_sleep_given(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -150,9 +115,7 @@ class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadMod
         new InMemoryEventStoreReadModelProjector($this->eventStore, 'test_projection', new ReadModelMock(), 1, 1, -1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_unknown_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -162,9 +125,7 @@ class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadMod
         new InMemoryEventStoreReadModelProjector($eventStore->reveal(), 'test_projection', new ReadModelMock(), 1, 1, 1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_wrapped_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -176,9 +137,7 @@ class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadMod
         new InMemoryEventStoreReadModelProjector($wrappedEventStore->reveal(), 'test_projection', new ReadModelMock(), 1, 1, 1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_allows_non_transactional_event_store_instance(): void
     {
         $eventStore = new NonTransactionalInMemoryEventStore();
@@ -187,10 +146,7 @@ class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadMod
         $this->assertInstanceOf(InMemoryEventStoreReadModelProjector::class, $projector);
     }
 
-    /**
-     * @test
-     * @medium
-     */
+    #[Test]
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {
         if (! \extension_loaded('pcntl')) {
@@ -222,10 +178,7 @@ class InMemoryEventStoreReadModelProjectorTest extends AbstractEventStoreReadMod
         );
     }
 
-    /**
-     * @test
-     * @small
-     */
+    #[Test]
     public function it_stops_immediately_after_pcntl_signal_was_received(): void
     {
         if (! \extension_loaded('pcntl')) {

--- a/tests/Projection/InMemoryProjectionManagerTest.php
+++ b/tests/Projection/InMemoryProjectionManagerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Projection;
 
+use PHPUnit\Framework\Attributes\Test;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception\InvalidArgumentException;
@@ -22,23 +23,16 @@ use Prooph\EventStore\NonTransactionalInMemoryEventStore;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
 use Prophecy\PhpUnit\ProphecyTrait;
 
-class InMemoryProjectionManagerTest extends AbstractProjectionManagerTest
+class InMemoryProjectionManagerTest extends AbstractProjectionManagerTestCase
 {
     use ProphecyTrait;
-
-    /**
-     * @var InMemoryProjectionManager
-     */
-    protected $projectionManager;
 
     protected function setUp(): void
     {
         $this->projectionManager = new InMemoryProjectionManager(new InMemoryEventStore());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -48,9 +42,7 @@ class InMemoryProjectionManagerTest extends AbstractProjectionManagerTest
         new InMemoryProjectionManager($eventStore->reveal());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_wrapped_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -62,9 +54,7 @@ class InMemoryProjectionManagerTest extends AbstractProjectionManagerTest
         new InMemoryProjectionManager($wrappedEventStore->reveal());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_allows_non_transactional_event_store_instance(): void
     {
         $eventStore = new NonTransactionalInMemoryEventStore();
@@ -73,9 +63,7 @@ class InMemoryProjectionManagerTest extends AbstractProjectionManagerTest
         $this->assertInstanceOf(InMemoryProjectionManager::class, $manager);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_cannot_delete_projections(): void
     {
         $this->expectException(RuntimeException::class);
@@ -83,9 +71,7 @@ class InMemoryProjectionManagerTest extends AbstractProjectionManagerTest
         $this->projectionManager->deleteProjection('foo', true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_cannot_reset_projections(): void
     {
         $this->expectException(RuntimeException::class);
@@ -93,9 +79,7 @@ class InMemoryProjectionManagerTest extends AbstractProjectionManagerTest
         $this->projectionManager->resetProjection('foo');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_cannot_stop_projections(): void
     {
         $this->expectException(RuntimeException::class);
@@ -103,49 +87,37 @@ class InMemoryProjectionManagerTest extends AbstractProjectionManagerTest
         $this->projectionManager->stopProjection('foo');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_delete_non_existing_projection(): void
     {
         $this->markTestSkipped('Deleting a projection is not supported in ' . InMemoryProjectionManager::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_reset_non_existing_projection(): void
     {
         $this->markTestSkipped('Resetting a projection is not supported in ' . InMemoryProjectionManager::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_trying_to_stop_non_existing_projection(): void
     {
         $this->markTestSkipped('Stopping a projection is not supported in ' . InMemoryProjectionManager::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_fail_deleting_twice(): void
     {
         $this->markTestSkipped('Deleting a projection is not supported in ' . InMemoryProjectionManager::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_fail_resetting_twice(): void
     {
         $this->markTestSkipped('Resetting a projection is not supported in ' . InMemoryProjectionManager::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_fail_stopping_twice(): void
     {
         $this->markTestSkipped('Stopping a projection is not supported in ' . InMemoryProjectionManager::class);

--- a/tests/ReadOnlyEventStoreWrapperTest.php
+++ b/tests/ReadOnlyEventStoreWrapperTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore;
 
+use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\ReadOnlyEventStoreWrapper;
@@ -24,16 +26,14 @@ class ReadOnlyEventStoreWrapperTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_delegates_method_calls_to_internal_event_store(): void
     {
         $eventStore = $this->prophesize(EventStore::class);
         $eventStore->fetchStreamMetadata(Argument::type(StreamName::class))->willReturn([])->shouldBeCalled();
         $eventStore->hasStream(Argument::type(StreamName::class))->willReturn(true)->shouldBeCalled();
-        $eventStore->load(Argument::type(StreamName::class), 0, 10, null)->willReturn(new \ArrayIterator())->shouldBeCalled();
-        $eventStore->loadReverse(Argument::type(StreamName::class), 0, 10, null)->willReturn(new \ArrayIterator())->shouldBeCalled();
+        $eventStore->load(Argument::type(StreamName::class), 0, 10, null)->willReturn(new ArrayIterator())->shouldBeCalled();
+        $eventStore->loadReverse(Argument::type(StreamName::class), 0, 10, null)->willReturn(new ArrayIterator())->shouldBeCalled();
         $eventStore->fetchStreamNames('foo', null, 0, 10)->willReturn(['foobar', 'foobaz'])->shouldBeCalled();
         $eventStore->fetchStreamNamesRegex('^foo', null, 0, 10)->willReturn(['foobar', 'foobaz'])->shouldBeCalled();
         $eventStore->fetchCategoryNames('foo', 0, 10)->willReturn(['foo-1', 'foo-2'])->shouldBeCalled();
@@ -45,8 +45,8 @@ class ReadOnlyEventStoreWrapperTest extends TestCase
 
         $this->assertEmpty($readOnlyEventStore->fetchStreamMetadata($testStream));
         $this->assertTrue($readOnlyEventStore->hasStream($testStream));
-        $this->assertInstanceOf(\ArrayIterator::class, $readOnlyEventStore->load($testStream, 0, 10));
-        $this->assertInstanceOf(\ArrayIterator::class, $readOnlyEventStore->loadReverse($testStream, 0, 10));
+        $this->assertInstanceOf(ArrayIterator::class, $readOnlyEventStore->load($testStream, 0, 10));
+        $this->assertInstanceOf(ArrayIterator::class, $readOnlyEventStore->loadReverse($testStream, 0, 10));
         $this->assertSame(['foobar', 'foobaz'], $readOnlyEventStore->fetchStreamNames('foo', null, 0, 10));
         $this->assertSame(['foobar', 'foobaz'], $readOnlyEventStore->fetchStreamNamesRegex('^foo', null, 0, 10));
         $this->assertSame(['foo-1', 'foo-2'], $readOnlyEventStore->fetchCategoryNames('foo', 0, 10));

--- a/tests/StreamIterator/EmptyStreamIteratorTest.php
+++ b/tests/StreamIterator/EmptyStreamIteratorTest.php
@@ -13,14 +13,15 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\StreamIterator;
 
+use EmptyIterator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\StreamIterator\EmptyStreamIterator;
 use Prooph\EventStore\StreamIterator\StreamIterator;
 
-class EmptyStreamIteratorTest extends AbstractStreamIteratorTest
+class EmptyStreamIteratorTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_implements_stream_iterator(): void
     {
         $iterator = new EmptyStreamIterator();
@@ -28,19 +29,15 @@ class EmptyStreamIteratorTest extends AbstractStreamIteratorTest
         $this->assertInstanceOf(StreamIterator::class, $iterator);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_implements_empty_iterator(): void
     {
         $iterator = new EmptyStreamIterator();
 
-        $this->assertInstanceOf(\EmptyIterator::class, $iterator);
+        $this->assertInstanceOf(EmptyIterator::class, $iterator);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_counts_correct(): void
     {
         $iterator = new EmptyStreamIterator();

--- a/tests/StreamIterator/InMemoryStreamIteratorTest.php
+++ b/tests/StreamIterator/InMemoryStreamIteratorTest.php
@@ -13,14 +13,15 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\StreamIterator;
 
+use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\StreamIterator\InMemoryStreamIterator;
 use Prooph\EventStore\StreamIterator\StreamIterator;
 
-class InMemoryStreamIteratorTest extends AbstractStreamIteratorTest
+class InMemoryStreamIteratorTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_implements_stream_iterator(): void
     {
         $iterator = new InMemoryStreamIterator();
@@ -28,13 +29,11 @@ class InMemoryStreamIteratorTest extends AbstractStreamIteratorTest
         $this->assertInstanceOf(StreamIterator::class, $iterator);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_implements_array_iterator(): void
     {
         $iterator = new InMemoryStreamIterator();
 
-        $this->assertInstanceOf(\ArrayIterator::class, $iterator);
+        $this->assertInstanceOf(ArrayIterator::class, $iterator);
     }
 }

--- a/tests/StreamIterator/MergedStreamIteratorTest.php
+++ b/tests/StreamIterator/MergedStreamIteratorTest.php
@@ -14,12 +14,14 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\StreamIterator;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\StreamIterator\InMemoryStreamIterator;
 use Prooph\EventStore\StreamIterator\MergedStreamIterator;
 use Prooph\EventStore\StreamIterator\StreamIterator;
 use ProophTest\EventStore\Mock\TestDomainEvent;
 
-class MergedStreamIteratorTest extends AbstractStreamIteratorTest
+class MergedStreamIteratorTest extends TestCase
 {
     public function getStreams(): array
     {
@@ -42,9 +44,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
         ];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_implements_stream_iterator(): void
     {
         $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
@@ -52,9 +52,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
         $this->assertInstanceOf(StreamIterator::class, $iterator);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_counts_correct(): void
     {
         $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
@@ -62,9 +60,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
         $this->assertEquals(9, $iterator->count());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_rewind(): void
     {
         $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
@@ -78,16 +74,14 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
         $this->assertEquals(0, $message->payload()['expected_index']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_messages_in_order(): void
     {
         $streams = $this->getStreams();
         $iterator = new MergedStreamIterator(\array_keys($streams), ...\array_values($streams));
 
         $index = 0;
-        foreach ($iterator as $position => $message) {
+        foreach ($iterator as $message) {
             $this->assertEquals($index, $message->payload()['expected_index']);
             $this->assertEquals($iterator->streamName(), $message->payload()['expected_stream_name']);
 
@@ -150,17 +144,14 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
         return $streams;
     }
 
-    /**
-     * @test
-     * @large
-     */
+    #[Test]
     public function it_returns_messages_in_order_for_large_streams(): void
     {
         $streams = $this->getStreamsLarge();
         $iterator = new MergedStreamIterator(\array_keys($streams), ...\array_values($streams));
 
         $index = 0;
-        foreach ($iterator as $position => $message) {
+        foreach ($iterator as $message) {
             $this->assertEquals($index, $message->payload()['expected_index']);
             $this->assertEquals($iterator->streamName(), $message->payload()['expected_stream_name']);
 
@@ -168,9 +159,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_messages_in_order_in_consideration_of_provided_stream_order(): void
     {
         $streams = [
@@ -187,7 +176,7 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
         $iterator = new MergedStreamIterator(\array_keys($streams), ...\array_values($streams));
 
         $index = 0;
-        foreach ($iterator as $position => $message) {
+        foreach ($iterator as $message) {
             $this->assertEquals($index, $message->payload()['expected_index']);
             $this->assertEquals($iterator->streamName(), $message->payload()['expected_stream_name']);
 
@@ -195,21 +184,17 @@ class MergedStreamIteratorTest extends AbstractStreamIteratorTest
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_correct_stream_name(): void
     {
         $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));
 
-        foreach ($iterator as $position => $message) {
+        foreach ($iterator as $message) {
             $this->assertEquals($iterator->streamName(), $message->payload()['expected_stream_name']);
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function key_represents_event_position(): void
     {
         $iterator = new MergedStreamIterator(\array_keys($this->getStreams()), ...\array_values($this->getStreams()));

--- a/tests/StreamIterator/StreamIteratorTest.php
+++ b/tests/StreamIterator/StreamIteratorTest.php
@@ -13,25 +13,24 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\StreamIterator;
 
+use Countable;
+use Iterator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\StreamIterator\StreamIterator;
 
-abstract class AbstractStreamIteratorTest extends TestCase
+class StreamIteratorTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_implements_iterator(): void
     {
-        $this->assertInstanceOf(\Iterator::class, $this->getStreamIteratorMock());
+        $this->assertInstanceOf(Iterator::class, $this->getStreamIteratorMock());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_implements_countable(): void
     {
-        $this->assertInstanceOf(\Countable::class, $this->getStreamIteratorMock());
+        $this->assertInstanceOf(Countable::class, $this->getStreamIteratorMock());
     }
 
     private function getStreamIteratorMock(): StreamIterator

--- a/tests/StreamNameTest.php
+++ b/tests/StreamNameTest.php
@@ -13,14 +13,13 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\StreamName;
 
 class StreamNameTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_delegates_to_string(): void
     {
         $streamName = new StreamName('foo');

--- a/tests/TransactionalActionEventEmitterEventStoreTest.php
+++ b/tests/TransactionalActionEventEmitterEventStoreTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore;
 
+use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Event\ProophActionEventEmitter;
 use Prooph\EventStore\Exception\TransactionAlreadyStarted;
@@ -28,10 +30,7 @@ class TransactionalActionEventEmitterEventStoreTest extends TestCase
     use EventStoreTestStreamTrait;
     use ProphecyTrait;
 
-    /**
-     * @var TransactionalActionEventEmitterEventStore
-     */
-    protected $eventStore;
+    protected TransactionalActionEventEmitterEventStore $eventStore;
 
     protected function setUp(): void
     {
@@ -40,9 +39,7 @@ class TransactionalActionEventEmitterEventStoreTest extends TestCase
         $this->eventStore = new TransactionalActionEventEmitterEventStore(new InMemoryEventStore(), $eventEmitter);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_works_transactional(): void
     {
         $streamName = $this->prophesize(StreamName::class);
@@ -52,7 +49,7 @@ class TransactionalActionEventEmitterEventStoreTest extends TestCase
         $stream = $this->prophesize(Stream::class);
         $stream->streamName()->willReturn($streamName);
         $stream->metadata()->willReturn(['foo' => 'bar'])->shouldBeCalled();
-        $stream->streamEvents()->willReturn(new \ArrayIterator());
+        $stream->streamEvents()->willReturn(new ArrayIterator());
 
         $this->eventStore->beginTransaction();
 
@@ -65,9 +62,7 @@ class TransactionalActionEventEmitterEventStoreTest extends TestCase
         $this->assertTrue($this->eventStore->hasStream($streamName));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_rolls_back_transaction(): void
     {
         $streamName = $this->prophesize(StreamName::class);
@@ -77,7 +72,7 @@ class TransactionalActionEventEmitterEventStoreTest extends TestCase
         $stream = $this->prophesize(Stream::class);
         $stream->streamName()->willReturn($streamName);
         $stream->metadata()->willReturn(['foo' => 'bar'])->shouldBeCalled();
-        $stream->streamEvents()->willReturn(new \ArrayIterator());
+        $stream->streamEvents()->willReturn(new ArrayIterator());
 
         $this->eventStore->beginTransaction();
 
@@ -92,9 +87,7 @@ class TransactionalActionEventEmitterEventStoreTest extends TestCase
         $this->assertFalse($this->eventStore->hasStream($streamName));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_no_transaction_started_on_commit(): void
     {
         $this->expectException(TransactionNotStarted::class);
@@ -102,9 +95,7 @@ class TransactionalActionEventEmitterEventStoreTest extends TestCase
         $this->eventStore->commit();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_no_transaction_started_on_rollback(): void
     {
         $this->expectException(TransactionNotStarted::class);
@@ -112,9 +103,7 @@ class TransactionalActionEventEmitterEventStoreTest extends TestCase
         $this->eventStore->rollback();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_transaction_already_started(): void
     {
         $this->expectException(TransactionAlreadyStarted::class);
@@ -123,9 +112,7 @@ class TransactionalActionEventEmitterEventStoreTest extends TestCase
         $this->eventStore->beginTransaction();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_wraps_up_code_in_transaction_properly(): void
     {
         $transactionResult = $this->eventStore->transactional(function (): string {

--- a/tests/TransactionalEventStoreTestTrait.php
+++ b/tests/TransactionalEventStoreTestTrait.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace ProophTest\EventStore;
 
 use ArrayIterator;
+use Exception;
+use PHPUnit\Framework\Attributes\Test;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Exception\StreamNotFound;
 use Prooph\EventStore\Exception\TransactionAlreadyStarted;
 use Prooph\EventStore\Exception\TransactionNotStarted;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
-use Prooph\EventStore\TransactionalEventStore;
 use ProophTest\EventStore\Mock\UsernameChanged;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -31,14 +32,7 @@ trait TransactionalEventStoreTestTrait
 {
     use ProphecyTrait;
 
-    /**
-     * @var TransactionalEventStore
-     */
-    protected $eventStore;
-
-    /**
-     * @test
-     */
+    #[Test]
     public function it_works_transactional(): void
     {
         $streamName = $this->prophesize(StreamName::class);
@@ -48,7 +42,7 @@ trait TransactionalEventStoreTestTrait
         $stream = $this->prophesize(Stream::class);
         $stream->streamName()->willReturn($streamName);
         $stream->metadata()->willReturn(['foo' => 'bar'])->shouldBeCalled();
-        $stream->streamEvents()->willReturn(new \ArrayIterator());
+        $stream->streamEvents()->willReturn(new ArrayIterator());
 
         $this->eventStore->beginTransaction();
 
@@ -59,9 +53,7 @@ trait TransactionalEventStoreTestTrait
         $this->assertTrue($this->eventStore->hasStream($streamName));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_wraps_up_code_in_transaction_properly(): void
     {
         $transactionResult = $this->eventStore->transactional(function (EventStore $eventStore): string {
@@ -92,9 +84,7 @@ trait TransactionalEventStoreTestTrait
         $this->assertCount(2, $streamEvents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_rolls_back_transaction(): void
     {
         $streamName = $this->prophesize(StreamName::class);
@@ -104,7 +94,7 @@ trait TransactionalEventStoreTestTrait
         $stream = $this->prophesize(Stream::class);
         $stream->streamName()->willReturn($streamName);
         $stream->metadata()->willReturn(['foo' => 'bar'])->shouldBeCalled();
-        $stream->streamEvents()->willReturn(new \ArrayIterator());
+        $stream->streamEvents()->willReturn(new ArrayIterator());
 
         $this->eventStore->beginTransaction();
 
@@ -117,12 +107,10 @@ trait TransactionalEventStoreTestTrait
         $this->assertFalse($this->eventStore->hasStream($streamName));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_should_rollback_and_throw_exception_in_case_of_transaction_fail(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Transaction failed');
 
         $eventStore = $this->eventStore;
@@ -130,13 +118,11 @@ trait TransactionalEventStoreTestTrait
         $this->eventStore->transactional(function (EventStore $es) use ($eventStore): void {
             $this->assertSame($es, $eventStore);
 
-            throw new \Exception('Transaction failed');
+            throw new Exception('Transaction failed');
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_should_return_true_by_default_if_transaction_is_used(): void
     {
         $transactionResult = $this->eventStore->transactional(function (EventStore $eventStore): void {
@@ -146,9 +132,7 @@ trait TransactionalEventStoreTestTrait
         $this->assertTrue($transactionResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_transaction_already_started(): void
     {
         $this->expectException(TransactionAlreadyStarted::class);
@@ -157,9 +141,7 @@ trait TransactionalEventStoreTestTrait
         $this->eventStore->beginTransaction();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_commit_empty_transaction(): void
     {
         $this->eventStore->beginTransaction();
@@ -168,9 +150,7 @@ trait TransactionalEventStoreTestTrait
         $this->assertFalse($this->eventStore->inTransaction());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_cannot_commit_twice(): void
     {
         $this->expectException(TransactionNotStarted::class);
@@ -180,9 +160,7 @@ trait TransactionalEventStoreTestTrait
         $this->eventStore->commit();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_rollback_empty_transaction(): void
     {
         $this->assertFalse($this->eventStore->inTransaction());
@@ -192,9 +170,7 @@ trait TransactionalEventStoreTestTrait
         $this->assertFalse($this->eventStore->inTransaction());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_cannot_rollback_twice(): void
     {
         $this->expectException(TransactionNotStarted::class);
@@ -204,9 +180,7 @@ trait TransactionalEventStoreTestTrait
         $this->eventStore->rollback();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_no_transaction_started_on_commit(): void
     {
         $this->expectException(TransactionNotStarted::class);
@@ -214,9 +188,7 @@ trait TransactionalEventStoreTestTrait
         $this->eventStore->commit();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_no_transaction_started_on_rollback(): void
     {
         $this->expectException(TransactionNotStarted::class);
@@ -224,9 +196,7 @@ trait TransactionalEventStoreTestTrait
         $this->eventStore->rollback();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_loads_and_saves_within_one_transaction(): void
     {
         $testStream = $this->getTestStream();

--- a/tests/Upcasting/NoOpEventUpcasterTest.php
+++ b/tests/Upcasting/NoOpEventUpcasterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Upcasting;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\Upcasting\NoOpEventUpcaster;
@@ -22,9 +23,7 @@ class NoOpEventUpcasterTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_nothing_during_upcast(): void
     {
         $message = $this->prophesize(Message::class);

--- a/tests/Upcasting/SingleEventUpcasterTest.php
+++ b/tests/Upcasting/SingleEventUpcasterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Upcasting;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\Upcasting\SingleEventUpcaster;
@@ -22,9 +23,7 @@ class SingleEventUpcasterTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_upcasts(): void
     {
         $upcastedMessage = $this->prophesize(Message::class);
@@ -43,9 +42,7 @@ class SingleEventUpcasterTest extends TestCase
         $this->assertSame($upcastedMessage, $messages[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_upcast_when_impossible(): void
     {
         $message = $this->prophesize(Message::class);

--- a/tests/Upcasting/UpcasterChainTest.php
+++ b/tests/Upcasting/UpcasterChainTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Upcasting;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\Upcasting\NoOpEventUpcaster;
@@ -25,9 +26,7 @@ class UpcasterChainTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_chains_upcasts(): void
     {
         $upcastedMessage3 = $this->prophesize(Message::class);
@@ -59,9 +58,7 @@ class UpcasterChainTest extends TestCase
         $this->assertSame($upcastedMessage3, $messages[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_doesnt_remove_messages_when_a_subsequent_upcaster_returns_fewer_messages(): void
     {
         $initialMessage = $this->prophesize(Message::class);

--- a/tests/Upcasting/UpcastingIteratorTest.php
+++ b/tests/Upcasting/UpcastingIteratorTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Upcasting;
 
+use ArrayIterator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\StreamIterator\EmptyStreamIterator;
@@ -26,9 +28,7 @@ class UpcastingIteratorTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_iterates(): void
     {
         $upcastedMessage1 = $this->prophesize(Message::class);
@@ -85,9 +85,7 @@ class UpcastingIteratorTest extends TestCase
         $this->assertNull($upcastingIterator->current());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_iterates_on_iterator_with_removed_messages_only(): void
     {
         $message = $this->prophesize(Message::class);
@@ -103,12 +101,10 @@ class UpcastingIteratorTest extends TestCase
         $this->assertNull($upcastingIterator->current());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_iterates_over_array_iterator(): void
     {
-        $iterator = new class() extends \ArrayIterator implements StreamIterator {
+        $iterator = new class() extends ArrayIterator implements StreamIterator {
         };
 
         $upcastingIterator = new UpcastingIterator($this->createUpcaster(), $iterator);
@@ -118,9 +114,7 @@ class UpcastingIteratorTest extends TestCase
         $this->assertNull($upcastingIterator->current());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_iterates_over_empty_iterator(): void
     {
         $iterator = new EmptyStreamIterator();
@@ -131,9 +125,7 @@ class UpcastingIteratorTest extends TestCase
         $this->assertNull($upcastingIterator->current());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_delegates_count_to_wrapped_iterator(): void
     {
         $iterator = new EmptyStreamIterator();

--- a/tests/Util/ArrayCacheTest.php
+++ b/tests/Util/ArrayCacheTest.php
@@ -13,27 +13,25 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Util;
 
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Util\ArrayCache;
 
 class ArrayCacheTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_invalid_size_given(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         new ArrayCache(-1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_too_high_position_given(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $cache = new ArrayCache(100);
 
@@ -42,21 +40,17 @@ class ArrayCacheTest extends TestCase
         $cache->get(101);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_too_low_position_given(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $cache = new ArrayCache(100);
 
         $cache->get(-1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_gets_checks_for_values(): void
     {
         $cache = new ArrayCache(4);


### PR DESCRIPTION
- upgrade to PHPUnit 10
- remove enforcing time limit as it may mark tests as risky
- test classes should be suffixed with `Test`
- abstract Test classes should be suffixed with `TestCase`
- remove remaining deprecations