### PR TITLE
Improve return types to prevent deprecation warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "phpspec/prophecy": "^1.10.3",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^10.0",
-        "prooph/bookdown-template": "^0.2.3",
         "prooph/php-cs-fixer-config": "^0.7.0",
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^2.0.1"

--- a/examples/event/QuickStartSucceeded.php
+++ b/examples/event/QuickStartSucceeded.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/examples/quickstart.php
+++ b/examples/quickstart.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/ActionEventEmitterEventStore.php
+++ b/src/ActionEventEmitterEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/InMemoryEventStoreFactory.php
+++ b/src/Container/InMemoryEventStoreFactory.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/InMemoryProjectionManagerFactory.php
+++ b/src/Container/InMemoryProjectionManagerFactory.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/EventStore.php
+++ b/src/EventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/EventStoreDecorator.php
+++ b/src/EventStoreDecorator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ConcurrencyException.php
+++ b/src/Exception/ConcurrencyException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/EventStoreException.php
+++ b/src/Exception/EventStoreException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ExtensionNotLoadedException.php
+++ b/src/Exception/ExtensionNotLoadedException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/OutOfRangeException.php
+++ b/src/Exception/OutOfRangeException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ProjectionNotFound.php
+++ b/src/Exception/ProjectionNotFound.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/StreamExistsAlready.php
+++ b/src/Exception/StreamExistsAlready.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/StreamNotFound.php
+++ b/src/Exception/StreamNotFound.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/TransactionAlreadyStarted.php
+++ b/src/Exception/TransactionAlreadyStarted.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/TransactionNotStarted.php
+++ b/src/Exception/TransactionNotStarted.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/InMemoryEventStore.php
+++ b/src/InMemoryEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/FieldType.php
+++ b/src/Metadata/FieldType.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/MetadataEnricher.php
+++ b/src/Metadata/MetadataEnricher.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/MetadataEnricherAggregate.php
+++ b/src/Metadata/MetadataEnricherAggregate.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/MetadataEnricherPlugin.php
+++ b/src/Metadata/MetadataEnricherPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/MetadataMatcher.php
+++ b/src/Metadata/MetadataMatcher.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Metadata/Operator.php
+++ b/src/Metadata/Operator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/NonTransactionalInMemoryEventStore.php
+++ b/src/NonTransactionalInMemoryEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Plugin/AbstractPlugin.php
+++ b/src/Plugin/AbstractPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Plugin/UpcastingPlugin.php
+++ b/src/Plugin/UpcastingPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/AbstractReadModel.php
+++ b/src/Projection/AbstractReadModel.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/InMemoryEventStoreProjector.php
+++ b/src/Projection/InMemoryEventStoreProjector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/InMemoryEventStoreQuery.php
+++ b/src/Projection/InMemoryEventStoreQuery.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/InMemoryEventStoreReadModelProjector.php
+++ b/src/Projection/InMemoryEventStoreReadModelProjector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/InMemoryProjectionManager.php
+++ b/src/Projection/InMemoryProjectionManager.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/MetadataAwareProjector.php
+++ b/src/Projection/MetadataAwareProjector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/MetadataAwareReadModelProjector.php
+++ b/src/Projection/MetadataAwareReadModelProjector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/ProjectionManager.php
+++ b/src/Projection/ProjectionManager.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/ProjectionStatus.php
+++ b/src/Projection/ProjectionStatus.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/Projector.php
+++ b/src/Projection/Projector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/Query.php
+++ b/src/Projection/Query.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/ReadModel.php
+++ b/src/Projection/ReadModel.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Projection/ReadModelProjector.php
+++ b/src/Projection/ReadModelProjector.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/ReadOnlyEventStore.php
+++ b/src/ReadOnlyEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/ReadOnlyEventStoreWrapper.php
+++ b/src/ReadOnlyEventStoreWrapper.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/EmptyStreamIterator.php
+++ b/src/StreamIterator/EmptyStreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/InMemoryStreamIterator.php
+++ b/src/StreamIterator/InMemoryStreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/MergedStreamIterator.php
+++ b/src/StreamIterator/MergedStreamIterator.php
@@ -63,6 +63,7 @@ class MergedStreamIterator implements StreamIterator
         $this->prioritizeIterators();
     }
 
+    /** @return mixed */
     #[\ReturnTypeWillChange]
     public function current()
     {

--- a/src/StreamIterator/MergedStreamIterator.php
+++ b/src/StreamIterator/MergedStreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/StreamIterator.php
+++ b/src/StreamIterator/StreamIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamIterator/TimSort.php
+++ b/src/StreamIterator/TimSort.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/StreamName.php
+++ b/src/StreamName.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/TransactionalActionEventEmitterEventStore.php
+++ b/src/TransactionalActionEventEmitterEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/TransactionalEventStore.php
+++ b/src/TransactionalEventStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/NoOpEventUpcaster.php
+++ b/src/Upcasting/NoOpEventUpcaster.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/SingleEventUpcaster.php
+++ b/src/Upcasting/SingleEventUpcaster.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/Upcaster.php
+++ b/src/Upcasting/Upcaster.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/UpcasterChain.php
+++ b/src/Upcasting/UpcasterChain.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Upcasting/UpcastingIterator.php
+++ b/src/Upcasting/UpcastingIterator.php
@@ -82,8 +82,7 @@ final class UpcastingIterator implements StreamIterator
         }
     }
 
-    #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): mixed
     {
         return $this->innerIterator->key();
     }

--- a/src/Upcasting/UpcastingIterator.php
+++ b/src/Upcasting/UpcastingIterator.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Util/ArrayCache.php
+++ b/src/Util/ArrayCache.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Util/Assertion.php
+++ b/src/Util/Assertion.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/AbstractActionEventEmitterEventStoreTestCase.php
+++ b/tests/AbstractActionEventEmitterEventStoreTestCase.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/AbstractEventStoreTestCase.php
+++ b/tests/AbstractEventStoreTestCase.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/ActionEventEmitterEventStoreTest.php
+++ b/tests/ActionEventEmitterEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/InMemoryEventStoreFactoryTest.php
+++ b/tests/Container/InMemoryEventStoreFactoryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/InMemoryProjectionManagerFactoryTest.php
+++ b/tests/Container/InMemoryProjectionManagerFactoryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/EventStoreTestStreamTrait.php
+++ b/tests/EventStoreTestStreamTrait.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Example/QuickStartTest.php
+++ b/tests/Example/QuickStartTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/InMemoryEventStoreTest.php
+++ b/tests/InMemoryEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Metadata/MetadataEnricherAggregateTest.php
+++ b/tests/Metadata/MetadataEnricherAggregateTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Metadata/MetadataEnricherPluginTest.php
+++ b/tests/Metadata/MetadataEnricherPluginTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Metadata/MetadataMatcherTest.php
+++ b/tests/Metadata/MetadataMatcherTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/EventLoggerPlugin.php
+++ b/tests/Mock/EventLoggerPlugin.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/Post.php
+++ b/tests/Mock/Post.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/PostCreated.php
+++ b/tests/Mock/PostCreated.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/Product.php
+++ b/tests/Mock/Product.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/ReadModelMock.php
+++ b/tests/Mock/ReadModelMock.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/TestDomainEvent.php
+++ b/tests/Mock/TestDomainEvent.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/TestIteratorAggregate.php
+++ b/tests/Mock/TestIteratorAggregate.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/User.php
+++ b/tests/Mock/User.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/UserCreated.php
+++ b/tests/Mock/UserCreated.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/UsernameChanged.php
+++ b/tests/Mock/UsernameChanged.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/NonTransactionalInMemoryEventStoreTest.php
+++ b/tests/NonTransactionalInMemoryEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Plugin/PluginManagerTest.php
+++ b/tests/Plugin/PluginManagerTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Plugin/UpcastingPluginTest.php
+++ b/tests/Plugin/UpcastingPluginTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractEventStoreProjectorTestCase.php
+++ b/tests/Projection/AbstractEventStoreProjectorTestCase.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractEventStoreQueryTestCase.php
+++ b/tests/Projection/AbstractEventStoreQueryTestCase.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractEventStoreReadModelProjectorTestCase.php
+++ b/tests/Projection/AbstractEventStoreReadModelProjectorTestCase.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/AbstractProjectionManagerTestCase.php
+++ b/tests/Projection/AbstractProjectionManagerTestCase.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryEventStoreProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreProjectorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryEventStoreQueryTest.php
+++ b/tests/Projection/InMemoryEventStoreQueryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/InMemoryEventStoreReadModelProjectorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/InMemoryProjectionManagerTest.php
+++ b/tests/Projection/InMemoryProjectionManagerTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/isolated-long-running-projection.php
+++ b/tests/Projection/isolated-long-running-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/isolated-long-running-query.php
+++ b/tests/Projection/isolated-long-running-query.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/isolated-long-running-read-model-projection.php
+++ b/tests/Projection/isolated-long-running-read-model-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/isolated-projection.php
+++ b/tests/Projection/isolated-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Projection/isolated-read-model-projection.php
+++ b/tests/Projection/isolated-read-model-projection.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/ReadOnlyEventStoreWrapperTest.php
+++ b/tests/ReadOnlyEventStoreWrapperTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/EmptyStreamIteratorTest.php
+++ b/tests/StreamIterator/EmptyStreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/InMemoryStreamIteratorTest.php
+++ b/tests/StreamIterator/InMemoryStreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/MergedStreamIteratorTest.php
+++ b/tests/StreamIterator/MergedStreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamIterator/StreamIteratorTest.php
+++ b/tests/StreamIterator/StreamIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/StreamNameTest.php
+++ b/tests/StreamNameTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/TransactionalActionEventEmitterEventStoreTest.php
+++ b/tests/TransactionalActionEventEmitterEventStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/TransactionalEventStoreTestTrait.php
+++ b/tests/TransactionalEventStoreTestTrait.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Upcasting/NoOpEventUpcasterTest.php
+++ b/tests/Upcasting/NoOpEventUpcasterTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Upcasting/SingleEventUpcasterTest.php
+++ b/tests/Upcasting/SingleEventUpcasterTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Upcasting/UpcasterChainTest.php
+++ b/tests/Upcasting/UpcasterChainTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Upcasting/UpcastingIteratorTest.php
+++ b/tests/Upcasting/UpcastingIteratorTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Util/ArrayCacheTest.php
+++ b/tests/Util/ArrayCacheTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/event-store.
- * (c) 2014-2025 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2026 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2026 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
## What changed

- `UpcastingIterator::key()` gets a native `mixed` return type, replacing the `#[\ReturnTypeWillChange]` attribute and `@return mixed` docblock.
- `MergedStreamIterator::current()` and `UpcastingIterator::current()` retain their existing signatures - see below for why.
- `prooph/bookdown-template` is removed from `require-dev` as it requires `league/commonmark ~0.7` which only resolves to `0.19.x-dev`, incompatible with PHP 8+. This was breaking the entire CI pipeline.

----

`UpcastingIterator::key()` is safe because `UpcastingIterator` is `final` - no subclasses can exist, so adding a return type cannot break anyone.

The other two cannot use native types without a BC break:

- **`MergedStreamIterator::current()`** - `MergedStreamIterator` is not `final`. Adding any return type to a previously untyped method forces subclasses to declare a compatible type or receive a deprecation warning.
- **`UpcastingIterator::current()`** - already has `?Message`. Widening it to `mixed` is flagged as non-covariant by the BC checker, as callers may rely on the narrower type. Since `?Message` already satisfies `Iterator::current(): mixed` covariantly, no deprecation warning is generated and no change is needed.